### PR TITLE
Agent binding

### DIFF
--- a/authfd.c
+++ b/authfd.c
@@ -649,3 +649,32 @@ ssh_remove_all_identities(int sock, int version)
 	sshbuf_free(msg);
 	return r;
 }
+
+/* Binds a session ID to a hostkey via the initial KEX signature. */
+int
+ssh_agent_bind_hostkey(int sock, const struct sshkey *key,
+    const struct sshbuf *session_id, const struct sshbuf *signature,
+    int forwarding)
+{
+	struct sshbuf *msg;
+	int r;
+
+	if (key == NULL || session_id == NULL || signature == NULL)
+		return SSH_ERR_INVALID_ARGUMENT;
+	if ((msg = sshbuf_new()) == NULL)
+		return SSH_ERR_ALLOC_FAIL;
+	if ((r = sshbuf_put_u8(msg, SSH_AGENTC_EXTENSION)) != 0 ||
+	    (r = sshbuf_put_cstring(msg, "session-bind@openssh.com")) != 0 ||
+	    (r = sshkey_puts(key, msg)) != 0 ||
+	    (r = sshbuf_put_stringb(msg, session_id)) != 0 ||
+	    (r = sshbuf_put_stringb(msg, signature)) != 0 ||
+	    (r = sshbuf_put_u8(msg, forwarding ? 1 : 0)) != 0)
+		goto out;
+	if ((r = ssh_request_reply_decode(sock, msg)) != 0)
+		goto out;
+	/* success */
+	r = 0;
+ out:
+	sshbuf_free(msg);
+	return r;
+}

--- a/authfd.c
+++ b/authfd.c
@@ -453,12 +453,63 @@ ssh_agent_sign(int sock, const struct sshkey *key,
 
 /* Encode key for a message to the agent. */
 
+static int
+encode_dest_constraint_hop(struct sshbuf *m,
+    const struct dest_constraint_hop *dch)
+{
+	struct sshbuf *b;
+	u_int i;
+	int r;
+
+	if ((b = sshbuf_new()) == NULL)
+		return SSH_ERR_ALLOC_FAIL;
+	if ((r = sshbuf_put_cstring(b, dch->user)) != 0 ||
+	    (r = sshbuf_put_cstring(b, dch->hostname)) != 0 ||
+	    (r = sshbuf_put_string(b, NULL, 0)) != 0) /* reserved */
+		goto out;
+	for (i = 0; i < dch->nkeys; i++) {
+		if ((r = sshkey_puts(dch->keys[i], b)) != 0 ||
+		    (r = sshbuf_put_u8(b, dch->key_is_ca[i] != 0)) != 0)
+			goto out;
+	}
+	if ((r = sshbuf_put_stringb(m, b)) != 0)
+		goto out;
+	/* success */
+	r = 0;
+ out:
+	sshbuf_free(b);
+	return r;
+}
+
+static int
+encode_dest_constraint(struct sshbuf *m, const struct dest_constraint *dc)
+{
+	struct sshbuf *b;
+	int r;
+
+	if ((b = sshbuf_new()) == NULL)
+		return SSH_ERR_ALLOC_FAIL;
+	if ((r = encode_dest_constraint_hop(b, &dc->from) != 0) ||
+	    (r = encode_dest_constraint_hop(b, &dc->to) != 0) ||
+	    (r = sshbuf_put_string(b, NULL, 0)) != 0) /* reserved */
+		goto out;
+	if ((r = sshbuf_put_stringb(m, b)) != 0)
+		goto out;
+	/* success */
+	r = 0;
+ out:
+	sshbuf_free(b);
+	return r;
+}
 
 static int
 encode_constraints(struct sshbuf *m, u_int life, u_int confirm, u_int maxsign,
-    const char *provider)
+    const char *provider, struct dest_constraint **dest_constraints,
+    size_t ndest_constraints)
 {
 	int r;
+	struct sshbuf *b = NULL;
+	size_t i;
 
 	if (life != 0) {
 		if ((r = sshbuf_put_u8(m, SSH_AGENT_CONSTRAIN_LIFETIME)) != 0 ||
@@ -482,8 +533,26 @@ encode_constraints(struct sshbuf *m, u_int life, u_int confirm, u_int maxsign,
 		    (r = sshbuf_put_cstring(m, provider)) != 0)
 			goto out;
 	}
+	if (dest_constraints != NULL && ndest_constraints > 0) {
+		if ((b = sshbuf_new()) == NULL) {
+			r = SSH_ERR_ALLOC_FAIL;
+			goto out;
+		}
+		for (i = 0; i < ndest_constraints; i++) {
+			if ((r = encode_dest_constraint(b,
+			    dest_constraints[i])) != 0)
+				goto out;
+		}
+		if ((r = sshbuf_put_u8(m,
+		    SSH_AGENT_CONSTRAIN_EXTENSION)) != 0 ||
+		    (r = sshbuf_put_cstring(m,
+		    "restrict-destination-v00@openssh.com")) != 0 ||
+		    (r = sshbuf_put_stringb(m, b)) != 0)
+			goto out;
+	}
 	r = 0;
  out:
+	sshbuf_free(b);
 	return r;
 }
 
@@ -494,10 +563,12 @@ encode_constraints(struct sshbuf *m, u_int life, u_int confirm, u_int maxsign,
 int
 ssh_add_identity_constrained(int sock, struct sshkey *key,
     const char *comment, u_int life, u_int confirm, u_int maxsign,
-    const char *provider)
+    const char *provider, struct dest_constraint **dest_constraints,
+    size_t ndest_constraints)
 {
 	struct sshbuf *msg;
-	int r, constrained = (life || confirm || maxsign || provider);
+	int r, constrained = (life || confirm || maxsign ||
+	    provider || dest_constraints);
 	u_char type;
 
 	if ((msg = sshbuf_new()) == NULL)
@@ -535,7 +606,7 @@ ssh_add_identity_constrained(int sock, struct sshkey *key,
 	}
 	if (constrained &&
 	    (r = encode_constraints(msg, life, confirm, maxsign,
-	    provider)) != 0)
+	    provider, dest_constraints, ndest_constraints)) != 0)
 		goto out;
 	if ((r = ssh_request_reply_decode(sock, msg)) != 0)
 		goto out;
@@ -589,7 +660,8 @@ ssh_remove_identity(int sock, const struct sshkey *key)
  */
 int
 ssh_update_card(int sock, int add, const char *reader_id, const char *pin,
-    u_int life, u_int confirm)
+    u_int life, u_int confirm,
+    struct dest_constraint **dest_constraints, size_t ndest_constraints)
 {
 	struct sshbuf *msg;
 	int r, constrained = (life || confirm);
@@ -609,7 +681,8 @@ ssh_update_card(int sock, int add, const char *reader_id, const char *pin,
 	    (r = sshbuf_put_cstring(msg, pin)) != 0)
 		goto out;
 	if (constrained &&
-	    (r = encode_constraints(msg, life, confirm, 0, NULL)) != 0)
+	    (r = encode_constraints(msg, life, confirm, 0, NULL,
+	    dest_constraints, ndest_constraints)) != 0)
 		goto out;
 	if ((r = ssh_request_reply_decode(sock, msg)) != 0)
 		goto out;

--- a/authfd.h
+++ b/authfd.h
@@ -16,6 +16,8 @@
 #ifndef AUTHFD_H
 #define AUTHFD_H
 
+struct sshbuf;
+
 /* List of identities returned by ssh_fetch_identitylist() */
 struct ssh_identitylist {
 	size_t nkeys;
@@ -42,6 +44,10 @@ int	ssh_remove_all_identities(int sock, int version);
 int	ssh_agent_sign(int sock, const struct sshkey *key,
 	    u_char **sigp, size_t *lenp,
 	    const u_char *data, size_t datalen, const char *alg, u_int compat);
+
+int	ssh_agent_bind_hostkey(int sock, const struct sshkey *key,
+    const struct sshbuf *session_id, const struct sshbuf *signature,
+    int forwarding);
 
 /* Messages for the authentication agent connection. */
 #define SSH_AGENTC_REQUEST_RSA_IDENTITIES	1
@@ -75,6 +81,9 @@ int	ssh_agent_sign(int sock, const struct sshkey *key,
 #define SSH_AGENTC_ADD_RSA_ID_CONSTRAINED	24
 #define SSH2_AGENTC_ADD_ID_CONSTRAINED		25
 #define SSH_AGENTC_ADD_SMARTCARD_KEY_CONSTRAINED 26
+
+/* generic extension mechanism */
+#define SSH_AGENTC_EXTENSION			27
 
 #define	SSH_AGENT_CONSTRAIN_LIFETIME		1
 #define	SSH_AGENT_CONSTRAIN_CONFIRM		2

--- a/authfd.h
+++ b/authfd.h
@@ -17,12 +17,27 @@
 #define AUTHFD_H
 
 struct sshbuf;
+struct sshkey;
 
 /* List of identities returned by ssh_fetch_identitylist() */
 struct ssh_identitylist {
 	size_t nkeys;
 	struct sshkey **keys;
 	char **comments;
+};
+
+/* Key destination restrictions */
+struct dest_constraint_hop {
+	char *user;	/* wildcards allowed */
+	char *hostname; /* used to matching cert principals and for display */
+	int is_ca;
+	u_int nkeys;	/* number of entries in *both* 'keys' and 'key_is_ca' */
+	struct sshkey **keys;
+	int *key_is_ca;
+};
+struct dest_constraint {
+	struct dest_constraint_hop from;
+	struct dest_constraint_hop to;
 };
 
 int	ssh_get_authentication_socket(int *fdp);
@@ -33,12 +48,15 @@ int	ssh_lock_agent(int sock, int lock, const char *password);
 int	ssh_fetch_identitylist(int sock, struct ssh_identitylist **idlp);
 void	ssh_free_identitylist(struct ssh_identitylist *idl);
 int	ssh_add_identity_constrained(int sock, struct sshkey *key,
-	    const char *comment, u_int life, u_int confirm, u_int maxsign,
-	    const char *provider);
+    const char *comment, u_int life, u_int confirm, u_int maxsign,
+    const char *provider, struct dest_constraint **dest_constraints,
+    size_t ndest_constraints);
 int	ssh_agent_has_key(int sock, const struct sshkey *key);
 int	ssh_remove_identity(int sock, const struct sshkey *key);
 int	ssh_update_card(int sock, int add, const char *reader_id,
-	    const char *pin, u_int life, u_int confirm);
+	    const char *pin, u_int life, u_int confirm,
+	    struct dest_constraint **dest_constraints,
+	    size_t ndest_constraints);
 int	ssh_remove_all_identities(int sock, int version);
 
 int	ssh_agent_sign(int sock, const struct sshkey *key,

--- a/clientloop.c
+++ b/clientloop.c
@@ -1589,6 +1589,12 @@ client_request_agent(struct ssh *ssh, const char *request_type, int rchan)
 			debug_fr(r, "ssh_get_authentication_socket");
 		return NULL;
 	}
+	if ((r = ssh_agent_bind_hostkey(sock, ssh->kex->initial_hostkey,
+	    ssh->kex->session_id, ssh->kex->initial_sig, 1)) == 0)
+		debug_f("bound agent to hostkey");
+	else
+		debug2_fr(r, "ssh_agent_bind_hostkey");
+
 	c = channel_new(ssh, "authentication agent connection",
 	    SSH_CHANNEL_OPEN, sock, sock, -1,
 	    CHAN_X11_WINDOW_DEFAULT, CHAN_TCP_PACKET_DEFAULT, 0,

--- a/kex.c
+++ b/kex.c
@@ -682,6 +682,8 @@ kex_free(struct kex *kex)
 	sshbuf_free(kex->server_version);
 	sshbuf_free(kex->client_pub);
 	sshbuf_free(kex->session_id);
+	sshbuf_free(kex->initial_sig);
+	sshkey_free(kex->initial_hostkey);
 	free(kex->failed_choice);
 	free(kex->hostkey_alg);
 	free(kex->name);

--- a/kex.h
+++ b/kex.h
@@ -123,6 +123,7 @@ struct newkeys {
 };
 
 struct ssh;
+struct sshbuf;
 
 struct kex {
 	struct newkeys	*newkeys[MODE_MAX];
@@ -141,6 +142,8 @@ struct kex {
 	struct sshbuf *client_version;
 	struct sshbuf *server_version;
 	struct sshbuf *session_id;
+	struct sshbuf *initial_sig;
+	struct sshkey *initial_hostkey;
 	sig_atomic_t done;
 	u_int	flags;
 	int	hash_alg;

--- a/kexgen.c
+++ b/kexgen.c
@@ -215,8 +215,26 @@ input_kex_gen_reply(int type, u_int32_t seq, struct ssh *ssh)
 	    kex->hostkey_alg, ssh->compat, NULL)) != 0)
 		goto out;
 
-	if ((r = kex_derive_keys(ssh, hash, hashlen, shared_secret)) == 0)
-		r = kex_send_newkeys(ssh);
+	if ((r = kex_derive_keys(ssh, hash, hashlen, shared_secret)) != 0 ||
+	    (r = kex_send_newkeys(ssh)) != 0)
+		goto out;
+
+	/* save initial signature and hostkey */
+	if ((kex->flags & KEX_INITIAL) != 0) {
+		if (kex->initial_hostkey != NULL || kex->initial_sig != NULL) {
+			r = SSH_ERR_INTERNAL_ERROR;
+			goto out;
+		}
+		if ((kex->initial_sig = sshbuf_new()) == NULL) {
+			r = SSH_ERR_ALLOC_FAIL;
+			goto out;
+		}
+		if ((r = sshbuf_put(kex->initial_sig, signature, slen)) != 0)
+			goto out;
+		kex->initial_hostkey = server_host_key;
+		server_host_key = NULL;
+	}
+	/* success */
 out:
 	explicit_bzero(hash, sizeof(hash));
 	explicit_bzero(kex->c25519_client_key, sizeof(kex->c25519_client_key));

--- a/kexgexc.c
+++ b/kexgexc.c
@@ -199,8 +199,26 @@ input_kex_dh_gex_reply(int type, u_int32_t seq, struct ssh *ssh)
 	    hashlen, kex->hostkey_alg, ssh->compat, NULL)) != 0)
 		goto out;
 
-	if ((r = kex_derive_keys(ssh, hash, hashlen, shared_secret)) == 0)
-		r = kex_send_newkeys(ssh);
+	if ((r = kex_derive_keys(ssh, hash, hashlen, shared_secret)) != 0 ||
+	    (r = kex_send_newkeys(ssh)) != 0)
+		goto out;
+
+	/* save initial signature and hostkey */
+	if ((kex->flags & KEX_INITIAL) != 0) {
+		if (kex->initial_hostkey != NULL || kex->initial_sig != NULL) {
+			r = SSH_ERR_INTERNAL_ERROR;
+			goto out;
+		}
+		if ((kex->initial_sig = sshbuf_new()) == NULL) {
+			r = SSH_ERR_ALLOC_FAIL;
+			goto out;
+		}
+		if ((r = sshbuf_put(kex->initial_sig, signature, slen)) != 0)
+			goto out;
+		kex->initial_hostkey = server_host_key;
+		server_host_key = NULL;
+	}
+	/* success */
  out:
 	explicit_bzero(hash, sizeof(hash));
 	DH_free(kex->dh);

--- a/ssh-add.c
+++ b/ssh-add.c
@@ -65,6 +65,7 @@
 #include "digest.h"
 #include "ssh-sk.h"
 #include "sk-api.h"
+#include "hostfile.h"
 
 /* argv0 */
 extern char *__progname;
@@ -224,7 +225,8 @@ delete_all(int agent_fd, int qflag)
 
 static int
 add_file(int agent_fd, const char *filename, int key_only, int qflag,
-    const char *skprovider)
+    const char *skprovider, struct dest_constraint **dest_constraints,
+    size_t ndest_constraints)
 {
 	struct sshkey *private, *cert;
 	char *comment = NULL;
@@ -358,7 +360,8 @@ add_file(int agent_fd, const char *filename, int key_only, int qflag,
 	}
 
 	if ((r = ssh_add_identity_constrained(agent_fd, private, comment,
-	    lifetime, confirm, maxsign, skprovider)) == 0) {
+	    lifetime, confirm, maxsign, skprovider,
+	    dest_constraints, ndest_constraints)) == 0) {
 		ret = 0;
 		if (!qflag) {
 			fprintf(stderr, "Identity added: %s (%s)\n",
@@ -410,7 +413,8 @@ add_file(int agent_fd, const char *filename, int key_only, int qflag,
 	sshkey_free(cert);
 
 	if ((r = ssh_add_identity_constrained(agent_fd, private, comment,
-	    lifetime, confirm, maxsign, skprovider)) != 0) {
+	    lifetime, confirm, maxsign, skprovider,
+	    dest_constraints, ndest_constraints)) != 0) {
 		error_r(r, "Certificate %s (%s) add failed", certpath,
 		    private->cert->key_id);
 		goto out;
@@ -438,7 +442,8 @@ add_file(int agent_fd, const char *filename, int key_only, int qflag,
 }
 
 static int
-update_card(int agent_fd, int add, const char *id, int qflag)
+update_card(int agent_fd, int add, const char *id, int qflag,
+    struct dest_constraint **dest_constraints, size_t ndest_constraints)
 {
 	char *pin = NULL;
 	int r, ret = -1;
@@ -450,7 +455,7 @@ update_card(int agent_fd, int add, const char *id, int qflag)
 	}
 
 	if ((r = ssh_update_card(agent_fd, add, id, pin == NULL ? "" : pin,
-	    lifetime, confirm)) == 0) {
+	    lifetime, confirm, dest_constraints, ndest_constraints)) == 0) {
 		ret = 0;
 		if (!qflag) {
 			fprintf(stderr, "Card %s: %s\n",
@@ -571,7 +576,8 @@ lock_agent(int agent_fd, int lock)
 }
 
 static int
-load_resident_keys(int agent_fd, const char *skprovider, int qflag)
+load_resident_keys(int agent_fd, const char *skprovider, int qflag,
+    struct dest_constraint **dest_constraints, size_t ndest_constraints)
 {
 	struct sshsk_resident_key **srks;
 	size_t nsrks, i;
@@ -591,7 +597,8 @@ load_resident_keys(int agent_fd, const char *skprovider, int qflag)
 		    fingerprint_hash, SSH_FP_DEFAULT)) == NULL)
 			fatal_f("sshkey_fingerprint failed");
 		if ((r = ssh_add_identity_constrained(agent_fd, key, "",
-		    lifetime, confirm, maxsign, skprovider)) != 0) {
+		    lifetime, confirm, maxsign, skprovider,
+		    dest_constraints, ndest_constraints)) != 0) {
 			error("Unable to add key %s %s", sshkey_type(key), fp);
 			free(fp);
 			ok = r;
@@ -621,23 +628,143 @@ load_resident_keys(int agent_fd, const char *skprovider, int qflag)
 
 static int
 do_file(int agent_fd, int deleting, int key_only, char *file, int qflag,
-    const char *skprovider)
+    const char *skprovider, struct dest_constraint **dest_constraints,
+    size_t ndest_constraints)
 {
 	if (deleting) {
 		if (delete_file(agent_fd, file, key_only, qflag) == -1)
 			return -1;
 	} else {
-		if (add_file(agent_fd, file, key_only, qflag, skprovider) == -1)
+		if (add_file(agent_fd, file, key_only, qflag, skprovider,
+		    dest_constraints, ndest_constraints) == -1)
 			return -1;
 	}
 	return 0;
 }
+
+/* Append string 's' to a NULL-terminated array of strings */
+static void
+stringlist_append(char ***listp, const char *s)
+{
+	size_t i = 0;
+
+	if (*listp == NULL)
+		*listp = xcalloc(2, sizeof(**listp));
+	else {
+		for (i = 0; (*listp)[i] != NULL; i++)
+			; /* count */
+		*listp = xrecallocarray(*listp, i + 1, i + 2, sizeof(**listp));
+	}
+	(*listp)[i] = xstrdup(s);
+}
+
+static void
+parse_dest_constraint_hop(const char *s, struct dest_constraint_hop *dch,
+    char **hostkey_files)
+{
+	char *user = NULL, *host, *os, *path;
+	size_t i;
+	struct hostkeys *hostkeys;
+	const struct hostkey_entry *hke;
+	int r, want_ca;
+
+	memset(dch, '\0', sizeof(*dch));
+	os = xstrdup(s);
+	if ((host = strchr(os, '@')) == NULL)
+		host = os;
+	else {
+		*host++ = '\0';
+		user = os;
+	}
+	cleanhostname(host);
+	/* Trivial case: username@ (all hosts) */
+	if (*host == '\0') {
+		if (user == NULL) {
+			fatal("Invalid key destination constraint \"%s\": "
+			    "does not specify user or host", s);
+		}
+		dch->user = xstrdup(user);
+		/* other fields left blank */
+		free(os);
+		return;
+	}
+	if (hostkey_files == NULL)
+		fatal_f("no hostkey files");
+	/* Otherwise we need to look up the keys for this hostname */
+	hostkeys = init_hostkeys();
+	for (i = 0; hostkey_files[i]; i++) {
+		path = tilde_expand_filename(hostkey_files[i], getuid());
+		debug2_f("looking up host keys for \"%s\" in %s", host, path);
+                load_hostkeys(hostkeys, host, path, 0);
+		free(path);
+	}
+	dch->user = user == NULL ? NULL : xstrdup(user);
+	dch->hostname = xstrdup(host);
+	for (i = 0; i < hostkeys->num_entries; i++) {
+		hke = hostkeys->entries + i;
+		want_ca = hke->marker == MRK_CA;
+		if (hke->marker != MRK_NONE && !want_ca)
+			continue;
+		debug3_f("%s%s%s: adding %s %skey from %s:%lu as key %u",
+		    user == NULL ? "": user, user == NULL ? "" : "@",
+		    host, sshkey_type(hke->key), want_ca ? "CA " : "",
+		    hke->file, hke->line, dch->nkeys);
+		dch->keys = xrecallocarray(dch->keys, dch->nkeys,
+		    dch->nkeys + 1, sizeof(*dch->keys));
+		dch->key_is_ca = xrecallocarray(dch->key_is_ca, dch->nkeys,
+		    dch->nkeys + 1, sizeof(*dch->key_is_ca));
+		if ((r = sshkey_from_private(hke->key,
+		    &(dch->keys[dch->nkeys]))) != 0)
+			fatal_fr(r, "sshkey_from_private");
+		dch->key_is_ca[dch->nkeys] = want_ca;
+		dch->nkeys++;
+	}
+	if (dch->nkeys == 0)
+		fatal("No host keys found for destination \"%s\"", host);
+	free_hostkeys(hostkeys);
+	free(os);
+	return;
+}
+
+static void
+parse_dest_constraint(const char *s, struct dest_constraint ***dcp,
+    size_t *ndcp, char **hostkey_files)
+{
+	struct dest_constraint *dc;
+	char *os, *cp;
+
+	dc = xcalloc(1, sizeof(*dc));
+	os = xstrdup(s);
+	if ((cp = strchr(os, '>')) == NULL) {
+		/* initial hop; no 'from' hop specified */
+		parse_dest_constraint_hop(os, &dc->to, hostkey_files);
+	} else {
+		/* two hops specified */
+		*(cp++) = '\0';
+		parse_dest_constraint_hop(os, &dc->from, hostkey_files);
+		parse_dest_constraint_hop(cp, &dc->to, hostkey_files);
+		if (dc->from.user != NULL) {
+			fatal("Invalid key constraint %s: cannot specify "
+			    "user on 'from' host", os);
+		}
+	}
+	debug2_f("constraint %zu: %s%s%s (%u keys) > %s%s%s (%u keys)", *ndcp,
+	    dc->from.user ? dc->from.user : "", dc->from.user ? "@" : "",
+	    dc->from.hostname ? dc->from.hostname : "(ORIGIN)", dc->from.nkeys,
+	    dc->to.user ? dc->to.user : "", dc->to.user ? "@" : "",
+	    dc->to.hostname ? dc->to.hostname : "(ANY)", dc->to.nkeys);
+	*dcp = xrecallocarray(*dcp, *ndcp, *ndcp + 1, sizeof(**dcp));
+	(*dcp)[(*ndcp)++] = dc;
+	free(os);
+}
+
 
 static void
 usage(void)
 {
 	fprintf(stderr,
 "usage: ssh-add [-cDdKkLlqvXx] [-E fingerprint_hash] [-S provider] [-t life]\n"
+"               [-H hostkey_file] [-h destination]\n"
 #ifdef WITH_XMSS
 "               [-M maxsign] [-m minleft]\n"
 #endif
@@ -655,10 +782,13 @@ main(int argc, char **argv)
 	extern int optind;
 	int agent_fd;
 	char *pkcs11provider = NULL, *skprovider = NULL;
+	char **dest_constraint_strings = NULL, **hostkey_files = NULL;
 	int r, i, ch, deleting = 0, ret = 0, key_only = 0, do_download = 0;
 	int xflag = 0, lflag = 0, Dflag = 0, qflag = 0, Tflag = 0;
 	SyslogFacility log_facility = SYSLOG_FACILITY_AUTH;
 	LogLevel log_level = SYSLOG_LEVEL_INFO;
+	struct dest_constraint **dest_constraints = NULL;
+	size_t ndest_constraints = 0;
 
 	/* Ensure that fds 0, 1 and 2 are open or directed to /dev/null */
 	sanitise_stdfd();
@@ -685,7 +815,7 @@ main(int argc, char **argv)
 
 	skprovider = getenv("SSH_SK_PROVIDER");
 
-	while ((ch = getopt(argc, argv, "vkKlLcdDTxXE:e:M:m:qs:S:t:")) != -1) {
+	while ((ch = getopt(argc, argv, "vkKlLcdDTxXE:e:h:H:M:m:qs:S:t:")) != -1) {
 		switch (ch) {
 		case 'v':
 			if (log_level == SYSLOG_LEVEL_INFO)
@@ -697,6 +827,12 @@ main(int argc, char **argv)
 			fingerprint_hash = ssh_digest_alg_by_name(optarg);
 			if (fingerprint_hash == -1)
 				fatal("Invalid hash algorithm \"%s\"", optarg);
+			break;
+		case 'H':
+			stringlist_append(&hostkey_files, optarg);
+			break;
+		case 'h':
+			stringlist_append(&dest_constraint_strings, optarg);
 			break;
 		case 'k':
 			key_only = 1;
@@ -791,6 +927,19 @@ main(int argc, char **argv)
 
 	if (skprovider == NULL)
 		skprovider = "internal";
+	if (hostkey_files == NULL) {
+		/* use defaults from readconf.c */
+		stringlist_append(&hostkey_files, _PATH_SSH_USER_HOSTFILE);
+		stringlist_append(&hostkey_files, _PATH_SSH_USER_HOSTFILE2);
+		stringlist_append(&hostkey_files, _PATH_SSH_SYSTEM_HOSTFILE);
+		stringlist_append(&hostkey_files, _PATH_SSH_SYSTEM_HOSTFILE2);
+	}
+	if (dest_constraint_strings != NULL) {
+		for (i = 0; dest_constraint_strings[i] != NULL; i++) {
+			parse_dest_constraint(dest_constraint_strings[i],
+			  &dest_constraints, &ndest_constraints, hostkey_files);
+		}
+	}
 
 	argc -= optind;
 	argv += optind;
@@ -804,14 +953,15 @@ main(int argc, char **argv)
 	}
 	if (pkcs11provider != NULL) {
 		if (update_card(agent_fd, !deleting, pkcs11provider,
-		    qflag) == -1)
+		    qflag, dest_constraints, ndest_constraints) == -1)
 			ret = 1;
 		goto done;
 	}
 	if (do_download) {
 		if (skprovider == NULL)
 			fatal("Cannot download keys without provider");
-		if (load_resident_keys(agent_fd, skprovider, qflag) != 0)
+		if (load_resident_keys(agent_fd, skprovider, qflag,
+		    dest_constraints, ndest_constraints) != 0)
 			ret = 1;
 		goto done;
 	}
@@ -834,7 +984,8 @@ main(int argc, char **argv)
 			if (stat(buf, &st) == -1)
 				continue;
 			if (do_file(agent_fd, deleting, key_only, buf,
-			    qflag, skprovider) == -1)
+			    qflag, skprovider,
+			    dest_constraints, ndest_constraints) == -1)
 				ret = 1;
 			else
 				count++;
@@ -844,7 +995,8 @@ main(int argc, char **argv)
 	} else {
 		for (i = 0; i < argc; i++) {
 			if (do_file(agent_fd, deleting, key_only,
-			    argv[i], qflag, skprovider) == -1)
+			    argv[i], qflag, skprovider,
+			    dest_constraints, ndest_constraints) == -1)
 				ret = 1;
 		}
 	}

--- a/ssh-add/Makefile
+++ b/ssh-add/Makefile
@@ -3,7 +3,7 @@
 .PATH:		${.CURDIR}/..
 
 SRCS=	ssh-add.c
-SRCS+=	authfd.c cleanup.c fatal.c readpass.c utf8.c
+SRCS+=	authfd.c cleanup.c fatal.c readpass.c utf8.c hostfile.c hmac.c
 SRCS+=	${SRCS_BASE} ${SRCS_KEY} ${SRCS_KEYP} ${SRCS_KRL} ${SRCS_UTL}
 SRCS+=	${SRCS_SK_CLIENT}
 

--- a/ssh-agent.c
+++ b/ssh-agent.c
@@ -84,9 +84,15 @@
 #endif
 
 /* Maximum accepted message length */
-#define AGENT_MAX_LEN	(256*1024)
+#define AGENT_MAX_LEN		(256*1024)
 /* Maximum bytes to read from client socket */
-#define AGENT_RBUF_LEN	(4096)
+#define AGENT_RBUF_LEN		(4096)
+/* Maximum number of recorded session IDs/hostkeys per connection */
+#define AGENT_MAX_SESSION_IDS		16
+/* Maximum size of session ID */
+#define AGENT_MAX_SID_LEN		128
+
+/* XXX store hostkey_sid in a refcounted tree */
 
 typedef enum {
 	AUTH_UNUSED = 0,
@@ -94,12 +100,20 @@ typedef enum {
 	AUTH_CONNECTION = 2,
 } sock_type;
 
+struct hostkey_sid {
+	struct sshkey *key;
+	struct sshbuf *sid;
+	int forwarded;
+};
+
 typedef struct socket_entry {
 	int fd;
 	sock_type type;
 	struct sshbuf *input;
 	struct sshbuf *output;
 	struct sshbuf *request;
+	size_t nsession_ids;
+	struct hostkey_sid *session_ids;
 } SocketEntry;
 
 u_int sockets_alloc = 0;
@@ -160,10 +174,17 @@ static int restrict_websafe = 1;
 static void
 close_socket(SocketEntry *e)
 {
+	size_t i;
+
 	close(e->fd);
 	sshbuf_free(e->input);
 	sshbuf_free(e->output);
 	sshbuf_free(e->request);
+	for (i = 0; i < e->nsession_ids; i++) {
+		sshkey_free(e->session_ids[i].key);
+		sshbuf_free(e->session_ids[i].sid);
+	}
+	free(e->session_ids);
 	memset(e, '\0', sizeof(*e));
 	e->fd = -1;
 	e->type = AUTH_UNUSED;
@@ -408,6 +429,18 @@ check_websafe_message_contents(struct sshkey *key, struct sshbuf *data)
 	return 0;
 }
 
+static int
+buf_equal(const struct sshbuf *a, const struct sshbuf *b)
+{
+	if (sshbuf_ptr(a) == NULL || sshbuf_ptr(b) == NULL)
+		return SSH_ERR_INVALID_ARGUMENT;
+	if (sshbuf_len(a) != sshbuf_len(b))
+		return SSH_ERR_INVALID_FORMAT;
+	if (timingsafe_bcmp(sshbuf_ptr(a), sshbuf_ptr(b), sshbuf_len(a)) != 0)
+		return SSH_ERR_INVALID_FORMAT;
+	return 0;
+}
+
 /* ssh2 only */
 static void
 process_sign_request2(SocketEntry *e)
@@ -416,8 +449,8 @@ process_sign_request2(SocketEntry *e)
 	size_t slen = 0;
 	u_int compat = 0, flags;
 	int r, ok = -1;
-	char *fp = NULL;
-	struct sshbuf *msg = NULL, *data = NULL;
+	char *fp = NULL, *user = NULL, *sig_dest = NULL;
+	struct sshbuf *msg = NULL, *data = NULL, *sid = NULL;
 	struct sshkey *key = NULL;
 	struct identity *id;
 	struct notifier_ctx *notifier = NULL;
@@ -437,7 +470,33 @@ process_sign_request2(SocketEntry *e)
 		verbose_f("%s key not found", sshkey_type(key));
 		goto send;
 	}
-	if (id->confirm && confirm_key(id, NULL) != 0) {
+	/*
+	 * If session IDs were recorded for this socket, then use them to
+	 * annotate the confirmation messages with the host keys.
+	 */
+	if (e->nsession_ids > 0 &&
+	    parse_userauth_request(data, key, &user, &sid) == 0) {
+		/*
+		 * session ID from userauth request should match the final
+		 * ID in the list recorded in the socket, unless the ssh
+		 * client at that point lacks the binding extension (or if
+		 * an attacker is trying to steal use of the agent).
+		 */
+		i = e->nsession_ids - 1;
+		if (buf_equal(sid, e->session_ids[i].sid) == 0) {
+			if ((fp = sshkey_fingerprint(e->session_ids[i].key,
+			    SSH_FP_HASH_DEFAULT, SSH_FP_DEFAULT)) == NULL)
+				fatal_f("fingerprint failed");
+			debug3_f("destination %s %s (slot %zu)",
+			    sshkey_type(e->session_ids[i].key), fp, i);
+			xasprintf(&sig_dest, "public key request for "
+			    "target user \"%s\" to %s %s", user,
+			    sshkey_type(e->session_ids[i].key), fp);
+			free(fp);
+			fp = NULL;
+		}
+	}
+	if (id->confirm && confirm_key(id, sig_dest) != 0) {
 		verbose_f("user refused key");
 		goto send;
 	}
@@ -452,8 +511,10 @@ process_sign_request2(SocketEntry *e)
 			    SSH_FP_DEFAULT)) == NULL)
 				fatal_f("fingerprint failed");
 			notifier = notify_start(0,
-			    "Confirm user presence for key %s %s",
-			    sshkey_type(id->key), fp);
+			    "Confirm user presence for key %s %s%s%s",
+			    sshkey_type(id->key), fp,
+			    sig_dest == NULL ? "" : "\n",
+			    sig_dest == NULL ? "" : sig_dest);
 		}
 	}
 	/* XXX support PIN required FIDO keys */
@@ -478,11 +539,14 @@ process_sign_request2(SocketEntry *e)
 	if ((r = sshbuf_put_stringb(e->output, msg)) != 0)
 		fatal_fr(r, "enqueue");
 
+	sshbuf_free(sid);
 	sshbuf_free(data);
 	sshbuf_free(msg);
 	sshkey_free(key);
 	free(fp);
 	free(signature);
+	free(sig_dest);
+	free(user);
 }
 
 /* shared */
@@ -944,6 +1008,97 @@ send:
 }
 #endif /* ENABLE_PKCS11 */
 
+static int
+process_ext_session_bind(SocketEntry *e)
+{
+	int r, sid_match, key_match;
+	struct sshkey *key = NULL;
+	struct sshbuf *sid = NULL, *sig = NULL;
+	char *fp = NULL;
+	size_t i;
+
+	debug2_f("entering");
+	if ((r = sshkey_froms(e->request, &key)) != 0 ||
+	    (r = sshbuf_froms(e->request, &sid)) != 0 ||
+	    (r = sshbuf_froms(e->request, &sig)) != 0 ||
+	    (r = sshbuf_get_u8(e->request, &fwd)) != 0) {
+		error_fr(r, "parse");
+		goto out;
+	}
+	if ((fp = sshkey_fingerprint(key, SSH_FP_HASH_DEFAULT,
+	    SSH_FP_DEFAULT)) == NULL)
+		fatal_f("fingerprint failed");
+	/* check signature with hostkey on session ID */
+	if ((r = sshkey_verify(key, sshbuf_ptr(sig), sshbuf_len(sig),
+	    sshbuf_ptr(sid), sshbuf_len(sid), NULL, 0, NULL)) != 0) {
+		error_fr(r, "sshkey_verify for %s %s", sshkey_type(key), fp);
+		goto out;
+	}
+	/* check whether sid/key already recorded */
+	for (i = 0; i < e->nsession_ids; i++) {
+		sid_match = buf_equal(sid, e->session_ids[i].sid) == 0;
+		key_match = sshkey_equal(key, e->session_ids[i].key);
+		if (sid_match && key_match) {
+			debug_f("session ID already recorded for %s %s",
+			    sshkey_type(key), fp);
+			r = 0;
+			goto out;
+		} else if (sid_match) {
+			error_f("session ID recorded against different key "
+			    "for %s %s", sshkey_type(key), fp);
+			r = -1;
+			goto out;
+		}
+		/*
+		 * new sid with previously-seen key can happen, e.g. multiple
+		 * connections to the same host.
+		 */
+	}
+	/* record new key/sid */
+	if (e->nsession_ids >= AGENT_MAX_SESSION_IDS) {
+		error_f("too many session IDs recorded");
+		goto out;
+	}
+	e->session_ids = xrecallocarray(e->session_ids, e->nsession_ids,
+	    e->nsession_ids + 1, sizeof(*e->session_ids));
+	i = e->nsession_ids++;
+	debug_f("recorded %s %s (slot %zu of %d)", sshkey_type(key), fp, i,
+	    AGENT_MAX_SESSION_IDS);
+	e->session_ids[i].key = key;
+	e->session_ids[i].forwarded = fwd != 0;
+	key = NULL; /* transferred */
+	/* can't transfer sid; it's refcounted and scoped to request's life */
+	if ((e->session_ids[i].sid = sshbuf_new()) == NULL)
+		fatal_f("sshbuf_new");
+	if ((r = sshbuf_putb(e->session_ids[i].sid, sid)) != 0)
+		fatal_fr(r, "sshbuf_putb session ID");
+	/* success */
+	r = 0;
+ out:
+	sshkey_free(key);
+	sshbuf_free(sid);
+	sshbuf_free(sig);
+	return r == 0 ? 1 : 0;
+}
+
+static void
+process_extension(SocketEntry *e)
+{
+	int r, success = 0;
+	char *name;
+
+	debug2_f("entering");
+	if ((r = sshbuf_get_cstring(e->request, &name, NULL)) != 0) {
+		error_fr(r, "parse");
+		goto send;
+	}
+	if (strcmp(name, "session-bind@openssh.com") == 0)
+		success = process_ext_session_bind(e);
+	else
+		debug_f("unsupported extension \"%s\"", name);
+send:
+	send_status(e, success);
+}
 /*
  * dispatch incoming message.
  * returns 1 on success, 0 for incomplete messages or -1 on error.
@@ -1036,6 +1191,9 @@ process_message(u_int socknum)
 		process_remove_smartcard_key(e);
 		break;
 #endif /* ENABLE_PKCS11 */
+	case SSH_AGENTC_EXTENSION:
+		process_extension(e);
+		break;
 	default:
 		/* Unknown message.  Respond with failure. */
 		error("Unknown message %d", type);

--- a/ssh-agent.c
+++ b/ssh-agent.c
@@ -78,6 +78,7 @@
 #include "pathnames.h"
 #include "ssh-pkcs11.h"
 #include "sk-api.h"
+#include "myproposal.h"
 
 #ifndef DEFAULT_ALLOWED_PROVIDERS
 # define DEFAULT_ALLOWED_PROVIDERS "/usr/lib*/*,/usr/local/lib*/*"
@@ -91,6 +92,8 @@
 #define AGENT_MAX_SESSION_IDS		16
 /* Maximum size of session ID */
 #define AGENT_MAX_SID_LEN		128
+/* Maximum number of destination constraints to accept on a key */
+#define AGENT_MAX_DEST_CONSTRAINTS	1024
 
 /* XXX store hostkey_sid in a refcounted tree */
 
@@ -127,6 +130,8 @@ typedef struct identity {
 	time_t death;
 	u_int confirm;
 	char *sk_provider;
+	struct dest_constraint *dest_constraints;
+	size_t ndest_constraints;
 } Identity;
 
 struct idtable {
@@ -199,13 +204,246 @@ idtab_init(void)
 }
 
 static void
+free_dest_constraint_hop(struct dest_constraint_hop *dch)
+{
+	u_int i;
+
+	if (dch == NULL)
+		return;
+	free(dch->user);
+	free(dch->hostname);
+	for (i = 0; i < dch->nkeys; i++)
+		sshkey_free(dch->keys[i]);
+	free(dch->keys);
+	free(dch->key_is_ca);
+}
+
+static void
+free_dest_constraints(struct dest_constraint *dcs, size_t ndcs)
+{
+	size_t i;
+
+	for (i = 0; i < ndcs; i++) {
+		free_dest_constraint_hop(&dcs[i].from);
+		free_dest_constraint_hop(&dcs[i].to);
+	}
+	free(dcs);
+}
+
+static void
 free_identity(Identity *id)
 {
 	sshkey_free(id->key);
 	free(id->provider);
 	free(id->comment);
 	free(id->sk_provider);
+	free_dest_constraints(id->dest_constraints, id->ndest_constraints);
 	free(id);
+}
+
+/*
+ * Match 'key' against the key/CA list in a destination constraint hop
+ * Returns 0 on success or -1 otherwise.
+ */
+static int
+match_key_hop(const char *tag, const struct sshkey *key,
+    const struct dest_constraint_hop *dch)
+{
+	const char *reason = NULL;
+	u_int i;
+	char *fp;
+
+	if (key == NULL)
+		return -1;
+	/* XXX logspam */
+	if ((fp = sshkey_fingerprint(key, SSH_FP_HASH_DEFAULT,
+	    SSH_FP_DEFAULT)) == NULL)
+		fatal_f("fingerprint failed");
+	debug3_f("%s: entering hostname %s, key %s %s", tag, dch->hostname,
+	    sshkey_type(key), fp);
+	free(fp);
+	for (i = 0; i < dch->nkeys; i++) {
+		if (dch->keys[i] == NULL)
+			return -1;
+		/* XXX logspam */
+		if ((fp = sshkey_fingerprint(dch->keys[i], SSH_FP_HASH_DEFAULT,
+		    SSH_FP_DEFAULT)) == NULL)
+			fatal_f("fingerprint failed");
+		debug3_f("%s: key %u: %s%s %s", tag, i,
+		    dch->key_is_ca[i] ? "CA " : "",
+		    sshkey_type(dch->keys[i]), fp);
+		free(fp);
+		if (!sshkey_is_cert(key)) {
+			/* plain key */
+			if (dch->key_is_ca[i] ||
+			    !sshkey_equal(key, dch->keys[i]))
+				continue;
+			return 0;
+		}
+		/* certificate */
+		if (!dch->key_is_ca[i])
+			continue;
+		if (key->cert == NULL || key->cert->signature_key == NULL)
+			return -1; /* shouldn't happen */
+		if (!sshkey_equal(key->cert->signature_key, dch->keys[i]))
+			continue;
+		if (sshkey_cert_check_host(key, dch->hostname, 1,
+		    SSH_ALLOWED_CA_SIGALGS, &reason) != 0) {
+			debug_f("cert %s / hostname %s rejected: %s",
+			    key->cert->key_id, dch->hostname, reason);
+			continue;
+		}
+		return 0;
+	}
+	return -1;
+}
+
+/* Check destination constraints on an identity against the hostkey/user */
+static int
+permitted_by_dest_constraints(const struct sshkey *fromkey,
+    const struct sshkey *tokey, Identity *id, const char *user,
+    const char **hostnamep)
+{
+	size_t i;
+	struct dest_constraint *d;
+
+	if (hostnamep != NULL)
+		*hostnamep = NULL;
+	for (i = 0; i < id->ndest_constraints; i++) {
+		d = id->dest_constraints + i;
+		/* XXX remove logspam */
+		debug2_f("constraint %zu %s%s%s (%u keys) > %s%s%s (%u keys)",
+		    i, d->from.user ? d->from.user : "",
+		    d->from.user ? "@" : "",
+		    d->from.hostname ? d->from.hostname : "(ORIGIN)",
+		    d->from.nkeys,
+		    d->to.user ? d->to.user : "", d->to.user ? "@" : "",
+		    d->to.hostname ? d->to.hostname : "(ANY)", d->to.nkeys);
+
+		/* Match 'from' key */
+		if (fromkey == NULL) {
+			/* We are matching the first hop */
+			if (d->from.hostname != NULL || d->from.nkeys != 0)
+				continue;
+		} else if (match_key_hop("from", fromkey, &d->from) != 0)
+			continue;
+
+		/* Match 'to' key */
+		if (tokey != NULL && match_key_hop("to", tokey, &d->to) != 0)
+			continue;
+
+		/* Match user if specified */
+		if (d->to.user != NULL && user != NULL &&
+		    !match_pattern(user, d->to.user))
+			continue;
+
+		/* successfully matched this constraint */
+		if (hostnamep != NULL)
+			*hostnamep = d->to.hostname;
+		debug2_f("allowed for hostname %s",
+		    d->to.hostname == NULL ? "*" : d->to.hostname);
+		return 0;
+	}
+	/* no match */
+	debug2_f("%s identity \"%s\" not permitted for this destination",
+	    sshkey_type(id->key), id->comment);
+	return -1;
+}
+
+/*
+ * Check whether hostkeys on a SocketEntry and the optionally specified user
+ * are permitted by the destination constraints on the Identity.
+ * Returns 0 on success or -1 otherwise.
+ */
+static int
+identity_permitted(Identity *id, SocketEntry *e, char *user,
+    const char **forward_hostnamep, const char **last_hostnamep)
+{
+	size_t i;
+	const char **hp;
+	struct hostkey_sid *hks;
+	const struct sshkey *fromkey = NULL;
+	const char *test_user;
+	char *fp1, *fp2;
+
+	/* XXX remove logspam */
+	debug3_f("entering: key %s comment \"%s\", %zu socket bindings, "
+	    "%zu constraints", sshkey_type(id->key), id->comment,
+	    e->nsession_ids, id->ndest_constraints);
+	if (id->ndest_constraints == 0)
+		return 0; /* unconstrained */
+	if (e->nsession_ids == 0)
+		return 0; /* local use */
+	/*
+	 * Walk through the hops recorded by session_id and try to find a
+	 * constraint that satisfies each.
+	 */
+	for (i = 0; i < e->nsession_ids; i++) {
+		hks = e->session_ids + i;
+		if (hks->key == NULL)
+			fatal_f("internal error: no bound key");
+		/* XXX remove logspam */
+		fp1 = fp2 = NULL;
+		if (fromkey != NULL &&
+		    (fp1 = sshkey_fingerprint(fromkey, SSH_FP_HASH_DEFAULT,
+		    SSH_FP_DEFAULT)) == NULL)
+			fatal_f("fingerprint failed");
+		if ((fp2 = sshkey_fingerprint(hks->key, SSH_FP_HASH_DEFAULT,
+		    SSH_FP_DEFAULT)) == NULL)
+			fatal_f("fingerprint failed");
+		debug3_f("socketentry fd=%d, entry %zu %s, "
+		    "from hostkey %s %s to user %s hostkey %s %s",
+		    e->fd, i, hks->forwarded ? "FORWARD" : "AUTH",
+		    fromkey ? sshkey_type(fromkey) : "(ORIGIN)",
+		    fromkey ? fp1 : "", user ? user : "(ANY)",
+		    sshkey_type(hks->key), fp2);
+		free(fp1);
+		free(fp2);
+		/*
+		 * Record the hostnames for the initial forwarding and
+		 * the final destination.
+		 */
+		hp = NULL;
+		if (i == e->nsession_ids - 1)
+			hp = last_hostnamep;
+		else if (i == 0)
+			hp = forward_hostnamep;
+		/* Special handling for final recorded binding */
+		test_user = NULL;
+		if (i == e->nsession_ids - 1) {
+			/* Can only check user at final hop */
+			test_user = user;
+			/*
+			 * user is only presented for signature requests.
+			 * If this is the case, make sure last binding is not
+			 * for a forwarding.
+			 */
+			if (hks->forwarded && user != NULL) {
+				error_f("tried to sign on forwarding hop");
+				return -1;
+			}
+		}
+		if (permitted_by_dest_constraints(fromkey, hks->key, id,
+		    test_user, hp) != 0)
+			return -1;
+		fromkey = hks->key;
+	}
+	/*
+	 * Another special case: if the last bound session ID was for a
+	 * forwarding, and this function is not being called to check a sign
+	 * request (i.e. no 'user' supplied), then only permit the key if
+	 * there is a permission that would allow it to be used at another
+	 * destination. This hides keys that are allowed to be used to
+	 * authenicate *to* a host but not permitted for *use* beyond it.
+	 */
+	if (e->session_ids[e->nsession_ids - 1].forwarded && user == NULL &&
+	    permitted_by_dest_constraints(fromkey, NULL, id, NULL, NULL) != 0) {
+		debug3_f("key permitted at host but not after");
+		return -1;
+	}
+
+	/* success */
+	return 0;
 }
 
 /* return matching private key for given public key */
@@ -255,27 +493,35 @@ static void
 process_request_identities(SocketEntry *e)
 {
 	Identity *id;
-	struct sshbuf *msg;
+	struct sshbuf *msg, *keys;
 	int r;
+	u_int nentries = 0;
 
 	debug2_f("entering");
 
-	if ((msg = sshbuf_new()) == NULL)
+	if ((msg = sshbuf_new()) == NULL || (keys = sshbuf_new()) == NULL)
 		fatal_f("sshbuf_new failed");
-	if ((r = sshbuf_put_u8(msg, SSH2_AGENT_IDENTITIES_ANSWER)) != 0 ||
-	    (r = sshbuf_put_u32(msg, idtab->nentries)) != 0)
-		fatal_fr(r, "compose");
 	TAILQ_FOREACH(id, &idtab->idlist, next) {
-		if ((r = sshkey_puts_opts(id->key, msg,
+		if (identity_permitted(id, e, NULL, NULL, NULL) != 0)
+			continue;
+		if ((r = sshkey_puts_opts(id->key, keys,
 		    SSHKEY_SERIALIZE_INFO)) != 0 ||
-		    (r = sshbuf_put_cstring(msg, id->comment)) != 0) {
+		    (r = sshbuf_put_cstring(keys, id->comment)) != 0) {
 			error_fr(r, "compose key/comment");
 			continue;
 		}
+		nentries++;
 	}
+	debug2_f("replying with %u allowed of %u available keys",
+	    nentries, idtab->nentries);
+	if ((r = sshbuf_put_u8(msg, SSH2_AGENT_IDENTITIES_ANSWER)) != 0 ||
+	    (r = sshbuf_put_u32(msg, nentries)) != 0 ||
+	    (r = sshbuf_putb(msg, keys)) != 0)
+		fatal_fr(r, "compose");
 	if ((r = sshbuf_put_stringb(e->output, msg)) != 0)
 		fatal_fr(r, "enqueue");
 	sshbuf_free(msg);
+	sshbuf_free(keys);
 }
 
 
@@ -450,6 +696,7 @@ process_sign_request2(SocketEntry *e)
 	u_int compat = 0, flags;
 	int r, ok = -1;
 	char *fp = NULL, *user = NULL, *sig_dest = NULL;
+	const char *fwd_host = NULL, *dest_host = NULL;
 	struct sshbuf *msg = NULL, *data = NULL, *sid = NULL;
 	struct sshkey *key = NULL;
 	struct identity *id;
@@ -470,31 +717,40 @@ process_sign_request2(SocketEntry *e)
 		verbose_f("%s key not found", sshkey_type(key));
 		goto send;
 	}
-	/*
-	 * If session IDs were recorded for this socket, then use them to
-	 * annotate the confirmation messages with the host keys.
-	 */
-	if (e->nsession_ids > 0 &&
-	    parse_userauth_request(data, key, &user, &sid) == 0) {
-		/*
-		 * session ID from userauth request should match the final
-		 * ID in the list recorded in the socket, unless the ssh
-		 * client at that point lacks the binding extension (or if
-		 * an attacker is trying to steal use of the agent).
-		 */
-		i = e->nsession_ids - 1;
-		if (buf_equal(sid, e->session_ids[i].sid) == 0) {
-			if ((fp = sshkey_fingerprint(e->session_ids[i].key,
-			    SSH_FP_HASH_DEFAULT, SSH_FP_DEFAULT)) == NULL)
-				fatal_f("fingerprint failed");
-			debug3_f("destination %s %s (slot %zu)",
-			    sshkey_type(e->session_ids[i].key), fp, i);
-			xasprintf(&sig_dest, "public key request for "
-			    "target user \"%s\" to %s %s", user,
-			    sshkey_type(e->session_ids[i].key), fp);
-			free(fp);
-			fp = NULL;
+	if ((fp = sshkey_fingerprint(key, SSH_FP_HASH_DEFAULT,
+	    SSH_FP_DEFAULT)) == NULL)
+		fatal_f("fingerprint failed");
+
+	if (id->ndest_constraints != 0) {
+		if (e->nsession_ids == 0) {
+			logit_f("refusing use of destination-constrained key "
+			    "to sign on unbound connection");
+			goto send;
 		}
+		if (parse_userauth_request(data, key, &user, &sid) != 0) {
+			logit_f("refusing use of destination-constrained key "
+			   "to sign an unidentified signature");
+			goto send;
+		}
+		/* XXX logspam */
+		debug_f("user=%s", user);
+		if (identity_permitted(id, e, user, &fwd_host, &dest_host) != 0)
+			goto send;
+		/*
+		 * Ensure that the session ID is the most recent one
+		 * registered on the socket - it should have been bound by
+		 * ssh immediately before userauth.
+		 */
+		if (buf_equal(sid,
+		    e->session_ids[e->nsession_ids - 1].sid) != 0) {
+			error_f("unexpected session ID (%zu listed) on "
+			    "signature request for target user %s with "
+			    "key %s %s", e->nsession_ids, user,
+			    sshkey_type(id->key), fp);
+			goto send;
+		}
+		xasprintf(&sig_dest, "public key authentication request for "
+		    "user \"%s\" to listed host", user);
 	}
 	if (id->confirm && confirm_key(id, sig_dest) != 0) {
 		verbose_f("user refused key");
@@ -507,9 +763,6 @@ process_sign_request2(SocketEntry *e)
 			goto send;
 		}
 		if ((id->key->sk_flags & SSH_SK_USER_PRESENCE_REQD)) {
-			if ((fp = sshkey_fingerprint(key, SSH_FP_HASH_DEFAULT,
-			    SSH_FP_DEFAULT)) == NULL)
-				fatal_f("fingerprint failed");
 			notifier = notify_start(0,
 			    "Confirm user presence for key %s %s%s%s",
 			    sshkey_type(id->key), fp,
@@ -566,6 +819,8 @@ process_remove_identity(SocketEntry *e)
 		debug_f("key not found");
 		goto done;
 	}
+	if (identity_permitted(id, e, NULL, NULL, NULL) != 0)
+		goto done; /* error already logged */
 	/* We have this key, free it. */
 	if (idtab->nentries < 1)
 		fatal_f("internal error: nentries %d", idtab->nentries);
@@ -625,10 +880,120 @@ reaper(void)
 }
 
 static int
-parse_key_constraint_extension(struct sshbuf *m, char **sk_providerp)
+parse_dest_constraint_hop(struct sshbuf *b, struct dest_constraint_hop *dch)
+{
+	u_char key_is_ca;
+	size_t elen = 0;
+	int r;
+	struct sshkey *k = NULL;
+	char *fp;
+
+	memset(dch, '\0', sizeof(*dch));
+	if ((r = sshbuf_get_cstring(b, &dch->user, NULL)) != 0 ||
+	    (r = sshbuf_get_cstring(b, &dch->hostname, NULL)) != 0 ||
+	    (r = sshbuf_get_string_direct(b, NULL, &elen)) != 0) {
+		error_fr(r, "parse");
+		goto out;
+	}
+	if (elen != 0) {
+		error_f("unsupported extensions (len %zu)", elen);
+		r = SSH_ERR_FEATURE_UNSUPPORTED;
+		goto out;
+	}
+	if (*dch->hostname == '\0') {
+		free(dch->hostname);
+		dch->hostname = NULL;
+	}
+	if (*dch->user == '\0') {
+		free(dch->user);
+		dch->user = NULL;
+	}
+	while (sshbuf_len(b) != 0) {
+		dch->keys = xrecallocarray(dch->keys, dch->nkeys,
+		    dch->nkeys + 1, sizeof(*dch->keys));
+		dch->key_is_ca = xrecallocarray(dch->key_is_ca, dch->nkeys,
+		    dch->nkeys + 1, sizeof(*dch->key_is_ca));
+		if ((r = sshkey_froms(b, &k)) != 0 ||
+		    (r = sshbuf_get_u8(b, &key_is_ca)) != 0)
+			goto out;
+		if ((fp = sshkey_fingerprint(k, SSH_FP_HASH_DEFAULT,
+		    SSH_FP_DEFAULT)) == NULL)
+			fatal_f("fingerprint failed");
+		debug3_f("%s%s%s: adding %skey %s %s",
+		    dch->user == NULL ? "" : dch->user,
+		    dch->user == NULL ? "" : "@",
+		    dch->hostname, key_is_ca ? "CA " : "", sshkey_type(k), fp);
+		free(fp);
+		dch->keys[dch->nkeys] = k;
+		dch->key_is_ca[dch->nkeys] = key_is_ca != 0;
+		dch->nkeys++;
+		k = NULL; /* transferred */
+	}
+	/* success */
+	r = 0;
+ out:
+	sshkey_free(k);
+	return r;
+}
+
+static int
+parse_dest_constraint(struct sshbuf *m, struct dest_constraint *dc)
+{
+	struct sshbuf *b = NULL, *frombuf = NULL, *tobuf = NULL;
+	int r;
+	size_t elen = 0;
+
+	debug3_f("entering");
+
+	memset(dc, '\0', sizeof(*dc));
+	if ((r = sshbuf_froms(m, &b)) != 0 ||
+	    (r = sshbuf_froms(b, &frombuf)) != 0 ||
+	    (r = sshbuf_froms(b, &tobuf)) != 0 ||
+	    (r = sshbuf_get_string_direct(b, NULL, &elen)) != 0) {
+		error_fr(r, "parse");
+		goto out;
+	}
+	if ((r = parse_dest_constraint_hop(frombuf, &dc->from) != 0) ||
+	    (r = parse_dest_constraint_hop(tobuf, &dc->to) != 0))
+		goto out; /* already logged */
+	if (elen != 0) {
+		error_f("unsupported extensions (len %zu)", elen);
+		r = SSH_ERR_FEATURE_UNSUPPORTED;
+		goto out;
+	}
+	debug2_f("parsed %s%s%s (%u keys) > %s%s%s (%u keys)",
+	    dc->from.user ? dc->from.user : "", dc->from.user ? "@" : "",
+	    dc->from.hostname ? dc->from.hostname : "(ORIGIN)", dc->from.nkeys,
+	    dc->to.user ? dc->to.user : "", dc->to.user ? "@" : "",
+	    dc->to.hostname ? dc->to.hostname : "(ANY)", dc->to.nkeys);
+	/* check consistency */
+	if ((dc->from.hostname == NULL) != (dc->from.nkeys == 0) ||
+	    dc->from.user != NULL) {
+		error_f("inconsistent \"from\" specification");
+		r = SSH_ERR_INVALID_FORMAT;
+		goto out;
+	}
+	if (dc->to.hostname == NULL || dc->to.nkeys == 0) {
+		error_f("incomplete \"to\" specification");
+		r = SSH_ERR_INVALID_FORMAT;
+		goto out;
+	}
+	/* success */
+	r = 0;
+ out:
+	sshbuf_free(b);
+	sshbuf_free(frombuf);
+	sshbuf_free(tobuf);
+	return r;
+}
+
+static int
+parse_key_constraint_extension(struct sshbuf *m, char **sk_providerp,
+    struct dest_constraint **dcsp, size_t *ndcsp)
 {
 	char *ext_name = NULL;
 	int r;
+	struct sshbuf *b = NULL;
 
 	if ((r = sshbuf_get_cstring(m, &ext_name, NULL)) != 0) {
 		error_fr(r, "parse constraint extension");
@@ -650,6 +1015,27 @@ parse_key_constraint_extension(struct sshbuf *m, char **sk_providerp)
 			error_fr(r, "parse %s", ext_name);
 			goto out;
 		}
+	} else if (strcmp(ext_name,
+	    "restrict-destination-v00@openssh.com") == 0) {
+		if (*dcsp != NULL) {
+			error_f("%s already set", ext_name);
+			goto out;
+		}
+		if ((r = sshbuf_froms(m, &b)) != 0) {
+			error_fr(r, "parse %s outer", ext_name);
+			goto out;
+		}
+		while (sshbuf_len(b) != 0) {
+			if (*ndcsp >= AGENT_MAX_DEST_CONSTRAINTS) {
+				error_f("too many %s constraints", ext_name);
+				goto out;
+			}
+			*dcsp = xrecallocarray(*dcsp, *ndcsp, *ndcsp + 1,
+			    sizeof(**dcsp));
+			if ((r = parse_dest_constraint(b,
+			    *dcsp + (*ndcsp)++)) != 0)
+				goto out; /* error already logged */
+		}
 	} else {
 		error_f("unsupported constraint \"%s\"", ext_name);
 		r = SSH_ERR_FEATURE_UNSUPPORTED;
@@ -659,12 +1045,13 @@ parse_key_constraint_extension(struct sshbuf *m, char **sk_providerp)
 	r = 0;
  out:
 	free(ext_name);
+	sshbuf_free(b);
 	return r;
 }
-
 static int
 parse_key_constraints(struct sshbuf *m, struct sshkey *k, time_t *deathp,
-    u_int *secondsp, int *confirmp, char **sk_providerp)
+    u_int *secondsp, int *confirmp, char **sk_providerp,
+    struct dest_constraint **dcsp, size_t *ndcsp)
 {
 	u_char ctype;
 	int r;
@@ -719,7 +1106,7 @@ parse_key_constraints(struct sshbuf *m, struct sshkey *k, time_t *deathp,
 			break;
 		case SSH_AGENT_CONSTRAIN_EXTENSION:
 			if ((r = parse_key_constraint_extension(m,
-			    sk_providerp)) != 0)
+			    sk_providerp, dcsp, ndcsp)) != 0)
 				goto out; /* error already logged */
 			break;
 		default:
@@ -743,6 +1130,8 @@ process_add_identity(SocketEntry *e)
 	char canonical_provider[PATH_MAX];
 	time_t death = 0;
 	u_int seconds = 0;
+	struct dest_constraint *dest_constraints = NULL;
+	size_t ndest_constraints = 0;
 	struct sshkey *k = NULL;
 	int r = SSH_ERR_INTERNAL_ERROR;
 
@@ -754,7 +1143,7 @@ process_add_identity(SocketEntry *e)
 		goto out;
 	}
 	if (parse_key_constraints(e->request, k, &death, &seconds, &confirm,
-	    &sk_provider) != 0) {
+	    &sk_provider, &dest_constraints, &ndest_constraints) != 0) {
 		error_f("failed to parse constraints");
 		sshbuf_reset(e->request);
 		goto out;
@@ -797,10 +1186,14 @@ process_add_identity(SocketEntry *e)
 		/* Increment the number of identities. */
 		idtab->nentries++;
 	} else {
+		if (identity_permitted(id, e, NULL, NULL, NULL) != 0)
+			goto out; /* error already logged */
 		/* key state might have been updated */
 		sshkey_free(id->key);
 		free(id->comment);
 		free(id->sk_provider);
+		free_dest_constraints(id->dest_constraints,
+		    id->ndest_constraints);
 	}
 	/* success */
 	id->key = k;
@@ -808,23 +1201,29 @@ process_add_identity(SocketEntry *e)
 	id->death = death;
 	id->confirm = confirm;
 	id->sk_provider = sk_provider;
+	id->dest_constraints = dest_constraints;
+	id->ndest_constraints = ndest_constraints;
 
 	if ((fp = sshkey_fingerprint(k, SSH_FP_HASH_DEFAULT,
 	    SSH_FP_DEFAULT)) == NULL)
 		fatal_f("sshkey_fingerprint failed");
 	debug_f("add %s %s \"%.100s\" (life: %u) (confirm: %u) "
-	    "(provider: %s)", sshkey_ssh_name(k), fp, comment, seconds,
-	    confirm, sk_provider == NULL ? "none" : sk_provider);
+	    "(provider: %s) (destination constraints: %zu)",
+	    sshkey_ssh_name(k), fp, comment, seconds, confirm,
+	    sk_provider == NULL ? "none" : sk_provider, ndest_constraints);
 	free(fp);
 	/* transferred */
 	k = NULL;
 	comment = NULL;
 	sk_provider = NULL;
+	dest_constraints = NULL;
+	ndest_constraints = 0;
 	success = 1;
  out:
 	free(sk_provider);
 	free(comment);
 	sshkey_free(k);
+	free_dest_constraints(dest_constraints, ndest_constraints);
 	send_status(e, success);
 }
 
@@ -907,6 +1306,8 @@ process_add_smartcard_key(SocketEntry *e)
 	time_t death = 0;
 	struct sshkey **keys = NULL, *k;
 	Identity *id;
+	struct dest_constraint *dest_constraints = NULL;
+	size_t ndest_constraints = 0;
 
 	debug2_f("entering");
 	if ((r = sshbuf_get_cstring(e->request, &provider, NULL)) != 0 ||
@@ -915,7 +1316,7 @@ process_add_smartcard_key(SocketEntry *e)
 		goto send;
 	}
 	if (parse_key_constraints(e->request, NULL, &death, &seconds, &confirm,
-	    NULL) != 0) {
+	    NULL, &dest_constraints, &ndest_constraints) != 0) {
 		error_f("failed to parse constraints");
 		goto send;
 	}
@@ -949,6 +1350,10 @@ process_add_smartcard_key(SocketEntry *e)
 			}
 			id->death = death;
 			id->confirm = confirm;
+			id->dest_constraints = dest_constraints;
+			id->ndest_constraints = ndest_constraints;
+			dest_constraints = NULL; /* transferred */
+			ndest_constraints = 0;
 			TAILQ_INSERT_TAIL(&idtab->idlist, id, next);
 			idtab->nentries++;
 			success = 1;
@@ -962,6 +1367,7 @@ send:
 	free(provider);
 	free(keys);
 	free(comments);
+	free_dest_constraints(dest_constraints, ndest_constraints);
 	send_status(e, success);
 }
 
@@ -1016,6 +1422,7 @@ process_ext_session_bind(SocketEntry *e)
 	struct sshbuf *sid = NULL, *sig = NULL;
 	char *fp = NULL;
 	size_t i;
+	u_char fwd = 0;
 
 	debug2_f("entering");
 	if ((r = sshkey_froms(e->request, &key)) != 0 ||
@@ -1053,6 +1460,12 @@ process_ext_session_bind(SocketEntry *e)
 		 * new sid with previously-seen key can happen, e.g. multiple
 		 * connections to the same host.
 		 */
+		if (!e->session_ids[i].forwarded) {
+			error_f("attempt to bind session ID to socket "
+			    "previously bound for authentication attempt");
+			r = -1;
+			goto out;
+		}
 	}
 	/* record new key/sid */
 	if (e->nsession_ids >= AGENT_MAX_SESSION_IDS) {

--- a/sshconnect.c
+++ b/sshconnect.c
@@ -1662,7 +1662,7 @@ maybe_add_key_to_agent(const char *authfile, struct sshkey *private,
 	if ((r = ssh_add_identity_constrained(auth_sock, private,
 	    comment == NULL ? authfile : comment,
 	    options.add_keys_to_agent_lifespan,
-	    (options.add_keys_to_agent == 3), 0, skprovider)) == 0)
+	    (options.add_keys_to_agent == 3), 0, skprovider, NULL, 0)) == 0)
 		debug("identity added to agent: %s", authfile);
 	else
 		debug("could not add identity to agent: %s (%d)", authfile, r);

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -384,7 +384,7 @@ void	userauth(struct ssh *, char *);
 
 static void pubkey_cleanup(struct ssh *);
 static int sign_and_send_pubkey(struct ssh *ssh, Identity *);
-static void pubkey_prepare(Authctxt *);
+static void pubkey_prepare(struct ssh *, Authctxt *);
 static void pubkey_reset(Authctxt *);
 static struct sshkey *load_identity_file(Identity *);
 
@@ -458,7 +458,7 @@ ssh_userauth2(struct ssh *ssh, const char *local_user,
 	authctxt.mech_tried = 0;
 #endif
 	authctxt.agent_fd = -1;
-	pubkey_prepare(&authctxt);
+	pubkey_prepare(ssh, &authctxt);
 	if (authctxt.method == NULL) {
 		fatal_f("internal error: cannot send userauth none request");
 	}
@@ -1624,6 +1624,36 @@ key_type_allowed_by_config(struct sshkey *key)
 	return 0;
 }
 
+/* obtain a list of keys from the agent */
+static int
+get_agent_identities(struct ssh *ssh, int *agent_fdp,
+    struct ssh_identitylist **idlistp)
+{
+	int r, agent_fd;
+	struct ssh_identitylist *idlist;
+
+	if ((r = ssh_get_authentication_socket(&agent_fd)) != 0) {
+		if (r != SSH_ERR_AGENT_NOT_PRESENT)
+			debug_fr(r, "ssh_get_authentication_socket");
+		return r;
+	}
+	if ((r = ssh_agent_bind_hostkey(agent_fd, ssh->kex->initial_hostkey,
+	    ssh->kex->session_id, ssh->kex->initial_sig, 0)) == 0)
+		debug_f("bound agent to hostkey");
+	else
+		debug2_fr(r, "ssh_agent_bind_hostkey");
+
+	if ((r = ssh_fetch_identitylist(agent_fd, &idlist)) != 0) {
+		debug_fr(r, "ssh_fetch_identitylist");
+		close(agent_fd);
+		return r;
+	}
+	/* success */
+	*agent_fdp = agent_fd;
+	*idlistp = idlist;
+	debug_f("agent returned %zu keys", idlist->nkeys);
+	return 0;
+}
 
 /*
  * try keys in the following order:
@@ -1634,7 +1664,7 @@ key_type_allowed_by_config(struct sshkey *key)
  *	5. keys that are only listed in the config file
  */
 static void
-pubkey_prepare(Authctxt *authctxt)
+pubkey_prepare(struct ssh *ssh, Authctxt *authctxt)
 {
 	struct identity *id, *id2, *tmp;
 	struct idlist agent, files, *preferred;
@@ -1696,14 +1726,7 @@ pubkey_prepare(Authctxt *authctxt)
 		TAILQ_INSERT_TAIL(preferred, id, next);
 	}
 	/* list of keys supported by the agent */
-	if ((r = ssh_get_authentication_socket(&agent_fd)) != 0) {
-		if (r != SSH_ERR_AGENT_NOT_PRESENT)
-			debug_fr(r, "ssh_get_authentication_socket");
-	} else if ((r = ssh_fetch_identitylist(agent_fd, &idlist)) != 0) {
-		if (r != SSH_ERR_AGENT_NO_IDENTITIES)
-			debug_fr(r, "ssh_fetch_identitylist");
-		close(agent_fd);
-	} else {
+	if ((r = get_agent_identities(ssh, &agent_fd, &idlist)) == 0) {
 		for (j = 0; j < idlist->nkeys; j++) {
 			found = 0;
 			TAILQ_FOREACH(id, &files, next) {


### PR DESCRIPTION
**NB.** This is work in progress. Please also see [PR#4](https://github.com/djmdjm/openssh-wip/pull/4) for an alternate, complementary approach and [PR#5](https://github.com/djmdjm/openssh-wip/pull/5) for a tree that combines both.

# Overview

These changes implement a key permission model for `ssh-agent` that allows granular control over which keys are available to particular destinations and forwarding hops. Destination hosts specified in these permissions are cryptographically verifiable by the agent.

Keys may be _destination restricted_ when they added to the agent by `ssh-add`. Destination restrictions take the form of one or more `[user@]host` or `host1>[user@]host2` strings, e.g.

```
ssh-add -h djm@example.org -h example.com -h 'example.org>example.net' ~/.ssh/id_ed25519
```

This would permit the key to be used to authenticate to any account on `example.com`, to user `djm` on `example.org`, and to `example.net` using an agent forwarded through `example.org`.

Internally, hosts are identified by their host keys. `ssh-add` will perform the name to key lookup using the `known_hosts` files on the system where was ran.

Connections forwarded across multiple hops must satisfy all restriction conditions for the keys to be usable at the destination. E.g. for the above set of restrictions (and assuming all hosts have independent host keys, the key is in `authorized_keys`, etc)

```
ssh -A djm@example.org ssh example.net # works
ssh -A example.com ssh djm@example.org # fails; no permission for 2nd hop
ssh -A example.org ssh root@example.net # fails (incorrect user)
```

# Implementation

This assumes familiarity with the SSH agent protocol [draft-miller-ssh-agent-04](https://tools.ietf.org/html/draft-miller-ssh-agent-04) and how it is used in practice.

Key permissions are built on a pair of agent protocol extensions: a trivial `restrict-destination-v00@openssh.com` [key constraint](https://tools.ietf.org/html/draft-miller-ssh-agent-04#section-4.2.6.3) that is used to encode the permissions attached to keys being added to the agent and and a new `session-bind@openssh.com` [extension request](https://tools.ietf.org/html/draft-miller-ssh-agent-04#section-4.7) that is used to cryptographically bind hostkeys to agent connections.

## Destination restriction key restrictions

_Destination restrictions_ are an array of permission tuples that may be attached to a key when it is added to `ssh-agent`. Each entry in the array identifies a single forwarding step that a key is allowed for. A forwarding step is identified its *source* host keys and *destination* user and host keys.

A special case is the initial authentication / forwarding step, from the host that is running `ssh-agent` locally. The step is distinguished by having no source host keys specified. All other steps must have both source and destination hostkeys present.

## Session / hostkey binding

The session binding mechanism depends on a number of SSH protocol features across the client, server and agent to establish a cryptographically provable binding between a _session ID_ and a SSH host key.

When a SSH connection is established, a key exchange process is performed between the client and server (e.g. using ECDH). One of the outputs of this process is a [session ID](https://tools.ietf.org/html/rfc4253#section-7.2) that is signed by the server to prove ownership of a host key. This same session ID is subsequently used to included in [public key authentication requests](https://tools.ietf.org/html/rfc4252#section-7) that are signed and sent by the client and verified by the server. The  session ID is included in the to-be-signed data to bind them to the connection instance, preventing replay of authentication attempts across connections.

The session ID is therefore cryptographically traceable to a host key **and** included in public key authentication requests. The `session-bind@openssh.com` extension takes advantage of these two properties. It allows a SSH client to communicate the to the agent the host key used in the initial key exchange, the session ID derived for the connection and the server's signature (over the session ID) proving the binding between them.

When the agent receives this binding on a connected socket, it verifies the signature and records the host key and session ID as _bound_ to that socket. When publickey authentication requests subsequently arrive on that socket, the agent may check the bound session ID against the session ID included in the authentication request to be signed, and the associated hostkey against the constraints associated with the key that will perform the signing. If one of these fails to match the signing request will be denied.

If a SSH agent is forwarded across multiple "hops" of SSH clients, each client will issue a `session-bind@openssh.com` request when it attempts to use or forward the agent. The agent connection will therefore accrue a list of `{session ID, hostkey}` that it may use to match against destination restrictions that it has set on loaded keys. This implementation requires hostkeys gathered on a chained connection be permitted by a destination restriction.

Certificate matching is slightly more complex than plain hostkey matching.  As per above, certificates are represented in destination restrictions by their CA key and a hostname wildcard pattern that is matched against the host certificate principals. This allows for common patterns of CA use such as whole domain `*.example.com` trust and individual hostname trust. 

# Protocol extension message formats

## Session binding

Session bindings are communicated using an [agent extension request](https://tools.ietf.org/html/draft-miller-ssh-agent-04#section-4.7):

```
       byte                    SSH_AGENTC_EXTENSION
       string                  "session-bind@openssh.com"
       string                  hostkey blob
       string                  session ID
       string                  signature
       bool                    is_forwarding
```

Where `is_forwarding` is a hint from the client as to whether this connection is intended solely for user authentication (false) or is a forwarding channel for arbitrary future requests (true).

## Destination restriction key constraint

Destination restrictions are encoded using a [key constraint extension](https://tools.ietf.org/html/draft-miller-ssh-agent-04#section-4.2.6.3) that may be attached to `SSH2_AGENTC_ADD_IDENTITY` and `SSH_AGENTC_ADD_SMARTCARD_KEY` requests. 

```
       byte                    SSH_AGENT_CONSTRAIN_EXTENSION
       string                  "restrict-destination-v00@openssh.com"
       string[]                permission
```

where each `permission` is the encoded tuple:

```
       string                  source_hop
       string                  dest_hop
       string                  reserved
```

The `reserved` string must be empty at this time. The source and desination hops are encoded as:

```
       string                  user
       string                  hostname
       string                  reserved
       byte[]                  key_specs
```
A zero-length `username` represents any user. The username in the source hop specification must be empty. `key_specs` is an array of:

```
       string                  hostkey blob
       bool                    ca_flag
```

If the `ca_flag` is set, then the correponding hostkey is assumed to be a trusted CA key for host names matching the `hostname` wildcard pattern. Otherwise, the hostkey directly specifies the expected host key for the destination and the `hostname` field is not used for permission checking (though it may still be used for display).

# Testing

A corresponding regression test is at https://github.com/djmdjm/openssh-regress-wip/pull/1

# Credits

Thanks to Markus Friedl and Jann Horn for providing useful feedback on the design and implementation.