### PR TITLE
Host-bound public key authentication

### DIFF
--- a/auth.h
+++ b/auth.h
@@ -95,7 +95,8 @@ struct Authctxt {
 
 struct Authmethod {
 	char	*name;
-	int	(*userauth)(struct ssh *);
+	char	*synonym;
+	int	(*userauth)(struct ssh *, const char *);
 	int	*enabled;
 };
 

--- a/auth2-gss.c
+++ b/auth2-gss.c
@@ -55,7 +55,7 @@ static int input_gssapi_errtok(int, u_int32_t, struct ssh *);
  * how to check local user kuserok and the like)
  */
 static int
-userauth_gssapi(struct ssh *ssh)
+userauth_gssapi(struct ssh *ssh, const char *method)
 {
 	Authctxt *authctxt = ssh->authctxt;
 	gss_OID_desc goid = {0, NULL};
@@ -324,6 +324,7 @@ input_gssapi_mic(int type, u_int32_t plen, struct ssh *ssh)
 
 Authmethod method_gssapi = {
 	"gssapi-with-mic",
+	NULL,
 	userauth_gssapi,
 	&options.gss_authentication
 };

--- a/auth2-hostbased.c
+++ b/auth2-hostbased.c
@@ -56,7 +56,7 @@
 extern ServerOptions options;
 
 static int
-userauth_hostbased(struct ssh *ssh)
+userauth_hostbased(struct ssh *ssh, const char *method)
 {
 	Authctxt *authctxt = ssh->authctxt;
 	struct sshbuf *b;
@@ -131,7 +131,7 @@ userauth_hostbased(struct ssh *ssh)
 	    (r = sshbuf_put_u8(b, SSH2_MSG_USERAUTH_REQUEST)) != 0 ||
 	    (r = sshbuf_put_cstring(b, authctxt->user)) != 0 ||
 	    (r = sshbuf_put_cstring(b, authctxt->service)) != 0 ||
-	    (r = sshbuf_put_cstring(b, "hostbased")) != 0 ||
+	    (r = sshbuf_put_cstring(b, method)) != 0 ||
 	    (r = sshbuf_put_string(b, pkalg, alen)) != 0 ||
 	    (r = sshbuf_put_string(b, pkblob, blen)) != 0 ||
 	    (r = sshbuf_put_cstring(b, chost)) != 0 ||
@@ -254,6 +254,7 @@ hostbased_key_allowed(struct ssh *ssh, struct passwd *pw,
 
 Authmethod method_hostbased = {
 	"hostbased",
+	NULL,
 	userauth_hostbased,
 	&options.hostbased_authentication
 };

--- a/auth2-kbdint.c
+++ b/auth2-kbdint.c
@@ -42,7 +42,7 @@
 extern ServerOptions options;
 
 static int
-userauth_kbdint(struct ssh *ssh)
+userauth_kbdint(struct ssh *ssh, const char *method)
 {
 	int r, authenticated = 0;
 	char *lang, *devs;
@@ -64,6 +64,7 @@ userauth_kbdint(struct ssh *ssh)
 
 Authmethod method_kbdint = {
 	"keyboard-interactive",
+	NULL,
 	userauth_kbdint,
 	&options.kbd_interactive_authentication
 };

--- a/auth2-none.c
+++ b/auth2-none.c
@@ -50,7 +50,7 @@ extern ServerOptions options;
 static int none_enabled = 1;
 
 static int
-userauth_none(struct ssh *ssh)
+userauth_none(struct ssh *ssh, const char *method)
 {
 	int r;
 
@@ -64,6 +64,7 @@ userauth_none(struct ssh *ssh)
 
 Authmethod method_none = {
 	"none",
+	NULL,
 	userauth_none,
 	&none_enabled
 };

--- a/auth2-passwd.c
+++ b/auth2-passwd.c
@@ -47,7 +47,7 @@
 extern ServerOptions options;
 
 static int
-userauth_passwd(struct ssh *ssh)
+userauth_passwd(struct ssh *ssh, const char *method)
 {
 	char *password;
 	int authenticated = 0, r;
@@ -70,6 +70,7 @@ userauth_passwd(struct ssh *ssh)
 
 Authmethod method_passwd = {
 	"password",
+	NULL,
 	userauth_passwd,
 	&options.password_authentication
 };

--- a/auth2-pubkey.c
+++ b/auth2-pubkey.c
@@ -64,6 +64,7 @@
 #include "authfile.h"
 #include "match.h"
 #include "ssherr.h"
+#include "kex.h"
 #include "channels.h" /* XXX for session.h */
 #include "session.h" /* XXX for child_set_env(); refactor? */
 #include "sk-api.h"
@@ -88,19 +89,34 @@ userauth_pubkey(struct ssh *ssh, const char *method)
 	Authctxt *authctxt = ssh->authctxt;
 	struct passwd *pw = authctxt->pw;
 	struct sshbuf *b = NULL;
-	struct sshkey *key = NULL;
+	struct sshkey *key = NULL, *hostkey = NULL;
 	char *pkalg = NULL, *userstyle = NULL, *key_s = NULL, *ca_s = NULL;
 	u_char *pkblob = NULL, *sig = NULL, have_sig;
 	size_t blen, slen;
-	int r, pktype;
+	int hostbound, r, pktype;
 	int req_presence = 0, req_verify = 0, authenticated = 0;
 	struct sshauthopt *authopts = NULL;
 	struct sshkey_sig_details *sig_details = NULL;
 
+	hostbound = strcmp(method, "publickey-hostbound-v00@openssh.com") == 0;
+
 	if ((r = sshpkt_get_u8(ssh, &have_sig)) != 0 ||
 	    (r = sshpkt_get_cstring(ssh, &pkalg, NULL)) != 0 ||
 	    (r = sshpkt_get_string(ssh, &pkblob, &blen)) != 0)
-		fatal_fr(r, "parse packet");
+		fatal_fr(r, "parse %s packet", method);
+
+	/* hostbound auth includes the hostkey offered at initial KEX */
+	if (hostbound) {
+		if ((r = sshpkt_getb_froms(ssh, &b)) != 0 ||
+		    (r = sshkey_fromb(b, &hostkey)) != 0)
+			fatal_fr(r, "parse %s hostkey", method);
+		if (ssh->kex->initial_hostkey == NULL)
+			fatal_f("internal error: initial hostkey not recorded");
+		if (!sshkey_equal(hostkey, ssh->kex->initial_hostkey))
+			fatal_f("%s packet contained wrong host key", method);
+		sshbuf_free(b);
+		b = NULL;
+	}
 
 	if (log_level_get() >= SYSLOG_LEVEL_DEBUG2) {
 		char *keystring;
@@ -163,7 +179,8 @@ userauth_pubkey(struct ssh *ssh, const char *method)
 		ca_s = format_key(key->cert->signature_key);
 
 	if (have_sig) {
-		debug3_f("have %s signature for %s%s%s", pkalg, key_s,
+		debug3_f("%s have %s signature for %s%s%s",
+		    method, pkalg, key_s,
 		    ca_s == NULL ? "" : " CA ", ca_s == NULL ? "" : ca_s);
 		if ((r = sshpkt_get_string(ssh, &sig, &slen)) != 0 ||
 		    (r = sshpkt_get_end(ssh)) != 0)
@@ -193,7 +210,10 @@ userauth_pubkey(struct ssh *ssh, const char *method)
 		    (r = sshbuf_put_u8(b, have_sig)) != 0 ||
 		    (r = sshbuf_put_cstring(b, pkalg)) != 0 ||
 		    (r = sshbuf_put_string(b, pkblob, blen)) != 0)
-			fatal_fr(r, "reconstruct packet");
+			fatal_fr(r, "reconstruct %s packet", method);
+		if (hostbound &&
+		    (r = sshkey_puts(ssh->kex->initial_hostkey, b)) != 0)
+			fatal_fr(r, "reconstruct %s packet", method);
 #ifdef DEBUG_PK
 		sshbuf_dump(b, stderr);
 #endif
@@ -243,7 +263,7 @@ userauth_pubkey(struct ssh *ssh, const char *method)
 		}
 		auth2_record_key(authctxt, authenticated, key);
 	} else {
-		debug_f("test pkalg %s pkblob %s%s%s", pkalg, key_s,
+		debug_f("%s test pkalg %s pkblob %s%s%s", method, pkalg, key_s,
 		    ca_s == NULL ? "" : " CA ", ca_s == NULL ? "" : ca_s);
 
 		if ((r = sshpkt_get_end(ssh)) != 0)
@@ -1064,7 +1084,7 @@ user_key_allowed(struct ssh *ssh, struct passwd *pw, struct sshkey *key,
 
 Authmethod method_pubkey = {
 	"publickey",
-	NULL,
+	"publickey-hostbound-v00@openssh.com",
 	userauth_pubkey,
 	&options.pubkey_authentication
 };

--- a/auth2-pubkey.c
+++ b/auth2-pubkey.c
@@ -83,7 +83,7 @@ format_key(const struct sshkey *key)
 }
 
 static int
-userauth_pubkey(struct ssh *ssh)
+userauth_pubkey(struct ssh *ssh, const char *method)
 {
 	Authctxt *authctxt = ssh->authctxt;
 	struct passwd *pw = authctxt->pw;
@@ -189,7 +189,7 @@ userauth_pubkey(struct ssh *ssh)
 		if ((r = sshbuf_put_u8(b, SSH2_MSG_USERAUTH_REQUEST)) != 0 ||
 		    (r = sshbuf_put_cstring(b, userstyle)) != 0 ||
 		    (r = sshbuf_put_cstring(b, authctxt->service)) != 0 ||
-		    (r = sshbuf_put_cstring(b, "publickey")) != 0 ||
+		    (r = sshbuf_put_cstring(b, method)) != 0 ||
 		    (r = sshbuf_put_u8(b, have_sig)) != 0 ||
 		    (r = sshbuf_put_cstring(b, pkalg)) != 0 ||
 		    (r = sshbuf_put_string(b, pkblob, blen)) != 0)
@@ -1064,6 +1064,7 @@ user_key_allowed(struct ssh *ssh, struct passwd *pw, struct sshkey *key,
 
 Authmethod method_pubkey = {
 	"publickey",
+	NULL,
 	userauth_pubkey,
 	&options.pubkey_authentication
 };

--- a/auth2.c
+++ b/auth2.c
@@ -314,7 +314,7 @@ input_userauth_request(int type, u_int32_t seq, struct ssh *ssh)
 	m = authmethod_lookup(authctxt, method);
 	if (m != NULL && authctxt->failures < options.max_authtries) {
 		debug2("input_userauth_request: try method %s", method);
-		authenticated =	m->userauth(ssh);
+		authenticated =	m->userauth(ssh, method);
 	}
 	if (!authctxt->authenticated)
 		ensure_minimum_time_since(tstart,
@@ -329,18 +329,26 @@ input_userauth_request(int type, u_int32_t seq, struct ssh *ssh)
 }
 
 void
-userauth_finish(struct ssh *ssh, int authenticated, const char *method,
+userauth_finish(struct ssh *ssh, int authenticated, const char *packet_method,
     const char *submethod)
 {
 	Authctxt *authctxt = ssh->authctxt;
+	Authmethod *m = NULL;
+	const char *method = packet_method;
 	char *methods;
 	int r, partial = 0;
 
-	if (!authctxt->valid && authenticated)
-		fatal("INTERNAL ERROR: authenticated invalid user %s",
-		    authctxt->user);
-	if (authenticated && authctxt->postponed)
-		fatal("INTERNAL ERROR: authenticated and postponed");
+	if (authenticated) {
+		if (!authctxt->valid) {
+			fatal("INTERNAL ERROR: authenticated invalid user %s",
+			    authctxt->user);
+		}
+		if (authctxt->postponed)
+			fatal("INTERNAL ERROR: authenticated and postponed");
+		if ((m = authmethod_lookup(authctxt, method)) == NULL)
+			fatal("INTERNAL ERROR: bad method %s", method);
+		method = m->name; /* prefer primary name to possible synonym */
+	}
 
 	/* Special handling for root */
 	if (authenticated && authctxt->pw->pw_uid == 0 &&
@@ -457,7 +465,9 @@ authmethod_lookup(Authctxt *authctxt, const char *name)
 		for (i = 0; authmethods[i] != NULL; i++)
 			if (authmethods[i]->enabled != NULL &&
 			    *(authmethods[i]->enabled) != 0 &&
-			    strcmp(name, authmethods[i]->name) == 0 &&
+			    (strcmp(name, authmethods[i]->name) == 0 ||
+			    (authmethods[i]->synonym != NULL &&
+			    strcmp(name, authmethods[i]->synonym) == 0)) &&
 			    auth2_method_allowed(authctxt,
 			    authmethods[i]->name, NULL))
 				return authmethods[i];

--- a/authfd.h
+++ b/authfd.h
@@ -16,11 +16,22 @@
 #ifndef AUTHFD_H
 #define AUTHFD_H
 
+struct sshbuf;
+struct sshkey;
+
 /* List of identities returned by ssh_fetch_identitylist() */
 struct ssh_identitylist {
 	size_t nkeys;
 	struct sshkey **keys;
 	char **comments;
+};
+
+/* Key destination restrictions */
+struct dest_constraint {
+	char *user;	/* wildcards allowed */
+	char *hostname; /* used to matching cert principals and for display */
+	int is_ca;
+	struct sshkey *key;
 };
 
 int	ssh_get_authentication_socket(int *fdp);
@@ -31,12 +42,14 @@ int	ssh_lock_agent(int sock, int lock, const char *password);
 int	ssh_fetch_identitylist(int sock, struct ssh_identitylist **idlp);
 void	ssh_free_identitylist(struct ssh_identitylist *idl);
 int	ssh_add_identity_constrained(int sock, struct sshkey *key,
-	    const char *comment, u_int life, u_int confirm, u_int maxsign,
-	    const char *provider);
+    const char *comment, u_int life, u_int confirm, u_int maxsign,
+    const char *provider, struct dest_constraint *dest_constraints,
+    size_t ndest_constraints);
 int	ssh_agent_has_key(int sock, const struct sshkey *key);
 int	ssh_remove_identity(int sock, const struct sshkey *key);
 int	ssh_update_card(int sock, int add, const char *reader_id,
-	    const char *pin, u_int life, u_int confirm);
+	    const char *pin, u_int life, u_int confirm,
+	    struct dest_constraint *dest_constraints, size_t ndest_constraints);
 int	ssh_remove_all_identities(int sock, int version);
 
 int	ssh_agent_sign(int sock, const struct sshkey *key,

--- a/kex.c
+++ b/kex.c
@@ -682,6 +682,7 @@ kex_free(struct kex *kex)
 	sshbuf_free(kex->server_version);
 	sshbuf_free(kex->client_pub);
 	sshbuf_free(kex->session_id);
+	sshkey_free(kex->initial_hostkey);
 	free(kex->failed_choice);
 	free(kex->hostkey_alg);
 	free(kex->name);

--- a/kex.c
+++ b/kex.c
@@ -421,9 +421,12 @@ kex_send_ext_info(struct ssh *ssh)
 		return SSH_ERR_ALLOC_FAIL;
 	/* XXX filter algs list by allowed pubkey/hostbased types */
 	if ((r = sshpkt_start(ssh, SSH2_MSG_EXT_INFO)) != 0 ||
-	    (r = sshpkt_put_u32(ssh, 1)) != 0 ||
+	    (r = sshpkt_put_u32(ssh, 2)) != 0 ||
 	    (r = sshpkt_put_cstring(ssh, "server-sig-algs")) != 0 ||
 	    (r = sshpkt_put_cstring(ssh, algs)) != 0 ||
+	    (r = sshpkt_put_cstring(ssh,
+	    "publickey-hostbound@openssh.com")) != 0 ||
+	    (r = sshpkt_put_cstring(ssh, "0")) != 0 ||
 	    (r = sshpkt_send(ssh)) != 0) {
 		error_fr(r, "compose");
 		goto out;
@@ -483,6 +486,21 @@ kex_input_ext_info(int type, u_int32_t seq, struct ssh *ssh)
 			debug_f("%s=<%s>", name, val);
 			kex->server_sig_algs = val;
 			val = NULL;
+		} else if (strcmp(name,
+		    "publickey-hostbound@openssh.com") == 0) {
+			/* XXX refactor */
+			/* Ensure no \0 lurking in value */
+			if (memchr(val, '\0', vlen) != NULL) {
+				error_f("nul byte in %s", name);
+				return SSH_ERR_INVALID_FORMAT;
+			}
+			debug_f("%s=<%s>", name, val);
+			if (strcmp(val, "0") == 0)
+				kex->flags |= KEX_HAS_PUBKEY_HOSTBOUND;
+			else {
+				debug_f("unsupported version of %s extension",
+				    name);
+			}
 		} else
 			debug_f("%s (unrecognised)", name);
 		free(name);

--- a/kex.h
+++ b/kex.h
@@ -146,6 +146,7 @@ struct kex {
 	int	hash_alg;
 	int	ec_nid;
 	char	*failed_choice;
+	struct sshkey *initial_hostkey;
 	int	(*verify_host_key)(struct sshkey *, struct ssh *);
 	struct sshkey *(*load_host_public_key)(int, int, struct ssh *);
 	struct sshkey *(*load_host_private_key)(int, int, struct ssh *);

--- a/kex.h
+++ b/kex.h
@@ -98,8 +98,10 @@ enum kex_exchange {
 	KEX_MAX
 };
 
-#define KEX_INIT_SENT	0x0001
-#define KEX_INITIAL	0x0002
+/* kex->flags */
+#define KEX_INIT_SENT			0x0001
+#define KEX_INITIAL			0x0002
+#define KEX_HAS_PUBKEY_HOSTBOUND	0x0004
 
 struct sshenc {
 	char	*name;

--- a/kexgen.c
+++ b/kexgen.c
@@ -215,8 +215,17 @@ input_kex_gen_reply(int type, u_int32_t seq, struct ssh *ssh)
 	    kex->hostkey_alg, ssh->compat, NULL)) != 0)
 		goto out;
 
-	if ((r = kex_derive_keys(ssh, hash, hashlen, shared_secret)) == 0)
-		r = kex_send_newkeys(ssh);
+	if ((r = kex_derive_keys(ssh, hash, hashlen, shared_secret)) != 0 ||
+	    (r = kex_send_newkeys(ssh)) != 0)
+		goto out;
+
+	/* success */
+
+	/* retain copy of hostkey used at initial KEX */
+	if (kex->initial_hostkey == NULL) {
+		kex->initial_hostkey = server_host_key;
+		server_host_key = NULL; /* transferred */
+	}
 out:
 	explicit_bzero(hash, sizeof(hash));
 	explicit_bzero(kex->c25519_client_key, sizeof(kex->c25519_client_key));
@@ -330,8 +339,15 @@ input_kex_gen_init(int type, u_int32_t seq, struct ssh *ssh)
 	    (r = sshpkt_send(ssh)) != 0)
 		goto out;
 
-	if ((r = kex_derive_keys(ssh, hash, hashlen, shared_secret)) == 0)
-		r = kex_send_newkeys(ssh);
+	if ((r = kex_derive_keys(ssh, hash, hashlen, shared_secret)) != 0 ||
+	    (r = kex_send_newkeys(ssh)) != 0)
+		goto out;
+	/* retain copy of hostkey used at initial KEX */
+	if (kex->initial_hostkey == NULL &&
+	    (r = sshkey_from_private(server_host_public,
+	    &kex->initial_hostkey)) != 0)
+		goto out;
+	/* success */
 out:
 	explicit_bzero(hash, sizeof(hash));
 	sshbuf_free(server_host_key_blob);

--- a/monitor.c
+++ b/monitor.c
@@ -997,11 +997,12 @@ static int
 monitor_valid_userblob(struct ssh *ssh, const u_char *data, u_int datalen)
 {
 	struct sshbuf *b;
+	struct sshkey *hostkey = NULL;
 	const u_char *p;
 	char *userstyle, *cp;
 	size_t len;
 	u_char type;
-	int r, fail = 0;
+	int hostbound = 0, r, fail = 0;
 
 	if ((b = sshbuf_from(data, datalen)) == NULL)
 		fatal_f("sshbuf_from");
@@ -1042,19 +1043,34 @@ monitor_valid_userblob(struct ssh *ssh, const u_char *data, u_int datalen)
 	if ((r = sshbuf_skip_string(b)) != 0 ||	/* service */
 	    (r = sshbuf_get_cstring(b, &cp, NULL)) != 0)
 		fatal_fr(r, "parse method");
-	if (strcmp("publickey", cp) != 0)
-		fail++;
+	if (strcmp("publickey", cp) != 0) {
+		if (strcmp("publickey-hostbound-v00@openssh.com", cp) == 0)
+			hostbound = 1;
+		else
+			fail++;
+	}
 	free(cp);
 	if ((r = sshbuf_get_u8(b, &type)) != 0)
 		fatal_fr(r, "parse pktype");
 	if (type == 0)
 		fail++;
 	if ((r = sshbuf_skip_string(b)) != 0 ||	/* pkalg */
-	    (r = sshbuf_skip_string(b)) != 0)	/* pkblob */
+	    (r = sshbuf_skip_string(b)) != 0 ||	/* pkblob */
+	    (hostbound && (r = sshkey_froms(b, &hostkey)) != 0))
 		fatal_fr(r, "parse pk");
 	if (sshbuf_len(b) != 0)
 		fail++;
 	sshbuf_free(b);
+	if (hostkey != NULL) {
+		/*
+		 * Ensure this is actually one of our hostkeys; unfortunately
+		 * can't check ssh->kex->initial_hostkey directly at this point
+		 * as packet state has not yet been exported to monitor.
+		 */
+		if (get_hostkey_index(hostkey, 1, ssh) == -1)
+			fatal_f("hostbound hostkey does not match");
+		sshkey_free(hostkey);
+	}
 	return (fail == 0);
 }
 

--- a/readconf.c
+++ b/readconf.c
@@ -876,6 +876,15 @@ static const struct multistate multistate_canonicalizehostname[] = {
 	{ "always",			SSH_CANONICALISE_ALWAYS },
 	{ NULL, -1 }
 };
+static const struct multistate multistate_pubkey_auth[] = {
+	{ "true",			SSH_PUBKEY_AUTH_ALL },
+	{ "false",			SSH_PUBKEY_AUTH_NO },
+	{ "yes",			SSH_PUBKEY_AUTH_ALL },
+	{ "no",				SSH_PUBKEY_AUTH_NO },
+	{ "unbound",			SSH_PUBKEY_AUTH_UNBOUND },
+	{ "host-bound",			SSH_PUBKEY_AUTH_HBIND },
+	{ NULL, -1 }
+};
 static const struct multistate multistate_compression[] = {
 #ifdef WITH_ZLIB
 	{ "yes",			COMP_ZLIB },
@@ -1088,8 +1097,9 @@ parse_time:
 		goto parse_string;
 
 	case oPubkeyAuthentication:
+		multistate_ptr = multistate_pubkey_auth;
 		intptr = &options->pubkey_authentication;
-		goto parse_flag;
+		goto parse_multistate;
 
 	case oHostbasedAuthentication:
 		intptr = &options->hostbased_authentication;
@@ -2473,7 +2483,7 @@ fill_default_options(Options * options)
 	if (options->fwd_opts.streamlocal_bind_unlink == -1)
 		options->fwd_opts.streamlocal_bind_unlink = 0;
 	if (options->pubkey_authentication == -1)
-		options->pubkey_authentication = 1;
+		options->pubkey_authentication = SSH_PUBKEY_AUTH_UNBOUND;
 	if (options->gss_authentication == -1)
 		options->gss_authentication = 0;
 	if (options->gss_deleg_creds == -1)
@@ -3116,6 +3126,8 @@ fmt_intarg(OpCodes code, int val)
 		return fmt_multistate_int(val, multistate_canonicalizehostname);
 	case oAddKeysToAgent:
 		return fmt_multistate_int(val, multistate_yesnoaskconfirm);
+	case oPubkeyAuthentication:
+		return fmt_multistate_int(val, multistate_pubkey_auth);
 	case oFingerprintHash:
 		return ssh_digest_alg_name(val);
 	default:

--- a/readconf.h
+++ b/readconf.h
@@ -179,6 +179,11 @@ typedef struct {
 	char	*ignored_unknown; /* Pattern list of unknown tokens to ignore */
 }       Options;
 
+#define SSH_PUBKEY_AUTH_NO	0x00
+#define SSH_PUBKEY_AUTH_UNBOUND	0x01
+#define SSH_PUBKEY_AUTH_HBIND	0x02
+#define SSH_PUBKEY_AUTH_ALL	0x03
+
 #define SSH_CANONICALISE_NO	0
 #define SSH_CANONICALISE_YES	1
 #define SSH_CANONICALISE_ALWAYS	2

--- a/ssh-add.c
+++ b/ssh-add.c
@@ -65,6 +65,7 @@
 #include "digest.h"
 #include "ssh-sk.h"
 #include "sk-api.h"
+#include "hostfile.h"
 
 /* argv0 */
 extern char *__progname;
@@ -224,7 +225,8 @@ delete_all(int agent_fd, int qflag)
 
 static int
 add_file(int agent_fd, const char *filename, int key_only, int qflag,
-    const char *skprovider)
+    const char *skprovider, struct dest_constraint *dest_constraints,
+    size_t ndest_constraints)
 {
 	struct sshkey *private, *cert;
 	char *comment = NULL;
@@ -358,7 +360,8 @@ add_file(int agent_fd, const char *filename, int key_only, int qflag,
 	}
 
 	if ((r = ssh_add_identity_constrained(agent_fd, private, comment,
-	    lifetime, confirm, maxsign, skprovider)) == 0) {
+	    lifetime, confirm, maxsign, skprovider,
+	    dest_constraints, ndest_constraints)) == 0) {
 		ret = 0;
 		if (!qflag) {
 			fprintf(stderr, "Identity added: %s (%s)\n",
@@ -410,7 +413,8 @@ add_file(int agent_fd, const char *filename, int key_only, int qflag,
 	sshkey_free(cert);
 
 	if ((r = ssh_add_identity_constrained(agent_fd, private, comment,
-	    lifetime, confirm, maxsign, skprovider)) != 0) {
+	    lifetime, confirm, maxsign, skprovider,
+	    dest_constraints, ndest_constraints)) != 0) {
 		error_r(r, "Certificate %s (%s) add failed", certpath,
 		    private->cert->key_id);
 		goto out;
@@ -438,7 +442,8 @@ add_file(int agent_fd, const char *filename, int key_only, int qflag,
 }
 
 static int
-update_card(int agent_fd, int add, const char *id, int qflag)
+update_card(int agent_fd, int add, const char *id, int qflag,
+    struct dest_constraint *dest_constraints, size_t ndest_constraints)
 {
 	char *pin = NULL;
 	int r, ret = -1;
@@ -450,7 +455,7 @@ update_card(int agent_fd, int add, const char *id, int qflag)
 	}
 
 	if ((r = ssh_update_card(agent_fd, add, id, pin == NULL ? "" : pin,
-	    lifetime, confirm)) == 0) {
+	    lifetime, confirm, dest_constraints, ndest_constraints)) == 0) {
 		ret = 0;
 		if (!qflag) {
 			fprintf(stderr, "Card %s: %s\n",
@@ -571,7 +576,8 @@ lock_agent(int agent_fd, int lock)
 }
 
 static int
-load_resident_keys(int agent_fd, const char *skprovider, int qflag)
+load_resident_keys(int agent_fd, const char *skprovider, int qflag,
+    struct dest_constraint *dest_constraints, size_t ndest_constraints)
 {
 	struct sshsk_resident_key **srks;
 	size_t nsrks, i;
@@ -591,7 +597,8 @@ load_resident_keys(int agent_fd, const char *skprovider, int qflag)
 		    fingerprint_hash, SSH_FP_DEFAULT)) == NULL)
 			fatal_f("sshkey_fingerprint failed");
 		if ((r = ssh_add_identity_constrained(agent_fd, key, "",
-		    lifetime, confirm, maxsign, skprovider)) != 0) {
+		    lifetime, confirm, maxsign, skprovider,
+		    dest_constraints, ndest_constraints)) != 0) {
 			error("Unable to add key %s %s", sshkey_type(key), fp);
 			free(fp);
 			ok = r;
@@ -621,16 +628,99 @@ load_resident_keys(int agent_fd, const char *skprovider, int qflag)
 
 static int
 do_file(int agent_fd, int deleting, int key_only, char *file, int qflag,
-    const char *skprovider)
+    const char *skprovider, struct dest_constraint *dest_constraints,
+    size_t ndest_constraints)
 {
 	if (deleting) {
 		if (delete_file(agent_fd, file, key_only, qflag) == -1)
 			return -1;
 	} else {
-		if (add_file(agent_fd, file, key_only, qflag, skprovider) == -1)
+		if (add_file(agent_fd, file, key_only, qflag, skprovider,
+		    dest_constraints, ndest_constraints) == -1)
 			return -1;
 	}
 	return 0;
+}
+
+static void
+stringlist_append(char ***listp, const char *s)
+{
+	size_t i = 0;
+
+	if (*listp == NULL)
+		*listp = xcalloc(2, sizeof(**listp));
+	else {
+		for (i = 0; (*listp)[i] != NULL; i++)
+			; /* count */
+		*listp = xrecallocarray(*listp, i + 1, i + 2, sizeof(**listp));
+	}
+	(*listp)[i++] = xstrdup(s);
+}
+
+static void
+parse_dest_constraint(const char *s, struct dest_constraint **dcp, size_t *ndcp,
+    char **hostkey_files)
+{
+	char *user = NULL, *host, *os, *path;
+	size_t i;
+	struct hostkeys *hostkeys;
+	const struct hostkey_entry *hke;
+	int r, want_ca;
+
+	os = xstrdup(s);
+	if ((host = strchr(os, '@')) == NULL)
+		host = os;
+	else {
+		*host++ = '\0';
+		user = os;
+	}
+	cleanhostname(host);
+	/* Trivial case: username@ (all hosts) */
+	if (*host == '\0') {
+		if (user == NULL) {
+			fatal("Invalid key destination constraint \"%s\": "
+			    "does not specify user or host", s);
+		}
+		*dcp = xrecallocarray(*dcp, *ndcp, *ndcp + 1, sizeof(**dcp));
+		(*dcp)[*ndcp].user = xstrdup(user);
+		/* other fields left blank */
+		(*ndcp)++;
+		free(os);
+		return;
+	}
+	if (hostkey_files == NULL)
+		fatal_f("no hostkey files");
+	/* Otherwise we need to look up the keys for this hostname */
+	hostkeys = init_hostkeys();
+	for (i = 0; hostkey_files[i]; i++) {
+		path = tilde_expand_filename(hostkey_files[i], getuid());
+		debug2_f("looking up host keys for \"%s\" in %s", host, path);
+                load_hostkeys(hostkeys, host, path, 0);
+		free(path);
+	}
+	if (hostkeys->num_entries == 0)
+		fatal("No host keys found for destination \"%s\"", host);
+	for (i = 0; i < hostkeys->num_entries; i++) {
+		hke = hostkeys->entries + i;
+		want_ca = hke->marker == MRK_CA;
+		if (hke->marker != MRK_NONE && !want_ca)
+			continue;
+		debug3_f("%s%s%s: adding %s %skey from %s:%lu as entry %zu",
+		    user == NULL ? "": user, user == NULL ? "" : "@",
+		    host, sshkey_type(hke->key), want_ca ? "CA " : "",
+		    hke->file, hke->line, *ndcp);
+		*dcp = xrecallocarray(*dcp, *ndcp, *ndcp + 1, sizeof(**dcp));
+		(*dcp)[*ndcp].user = user == NULL ? NULL : xstrdup(user);
+		(*dcp)[*ndcp].is_ca = want_ca;
+		(*dcp)[*ndcp].hostname = xstrdup(host);
+		if ((r = sshkey_from_private(hke->key,
+		    &((*dcp)[*ndcp].key))) != 0)
+			fatal_f("sshkey_from_private");
+		(*ndcp)++;
+	}
+	free_hostkeys(hostkeys);
+	free(os);
+	return;
 }
 
 static void
@@ -638,6 +728,7 @@ usage(void)
 {
 	fprintf(stderr,
 "usage: ssh-add [-cDdKkLlqvXx] [-E fingerprint_hash] [-S provider] [-t life]\n"
+"               [-H hostkey_file] [-h destination]\n"
 #ifdef WITH_XMSS
 "               [-M maxsign] [-m minleft]\n"
 #endif
@@ -655,10 +746,13 @@ main(int argc, char **argv)
 	extern int optind;
 	int agent_fd;
 	char *pkcs11provider = NULL, *skprovider = NULL;
+	char **dest_constraint_strings = NULL, **hostkey_files = NULL;
 	int r, i, ch, deleting = 0, ret = 0, key_only = 0, do_download = 0;
 	int xflag = 0, lflag = 0, Dflag = 0, qflag = 0, Tflag = 0;
 	SyslogFacility log_facility = SYSLOG_FACILITY_AUTH;
 	LogLevel log_level = SYSLOG_LEVEL_INFO;
+	struct dest_constraint *dest_constraints = NULL;
+	size_t ndest_constraints = 0;
 
 	/* Ensure that fds 0, 1 and 2 are open or directed to /dev/null */
 	sanitise_stdfd();
@@ -685,7 +779,7 @@ main(int argc, char **argv)
 
 	skprovider = getenv("SSH_SK_PROVIDER");
 
-	while ((ch = getopt(argc, argv, "vkKlLcdDTxXE:e:M:m:qs:S:t:")) != -1) {
+	while ((ch = getopt(argc, argv, "vkKlLcdDTxXE:e:h:H:M:m:qs:S:t:")) != -1) {
 		switch (ch) {
 		case 'v':
 			if (log_level == SYSLOG_LEVEL_INFO)
@@ -697,6 +791,12 @@ main(int argc, char **argv)
 			fingerprint_hash = ssh_digest_alg_by_name(optarg);
 			if (fingerprint_hash == -1)
 				fatal("Invalid hash algorithm \"%s\"", optarg);
+			break;
+		case 'H':
+			stringlist_append(&hostkey_files, optarg);
+			break;
+		case 'h':
+			stringlist_append(&dest_constraint_strings, optarg);
 			break;
 		case 'k':
 			key_only = 1;
@@ -791,6 +891,19 @@ main(int argc, char **argv)
 
 	if (skprovider == NULL)
 		skprovider = "internal";
+	if (hostkey_files == NULL) {
+		/* use defaults from readconf.c */
+		stringlist_append(&hostkey_files, _PATH_SSH_USER_HOSTFILE);
+		stringlist_append(&hostkey_files, _PATH_SSH_USER_HOSTFILE2);
+		stringlist_append(&hostkey_files, _PATH_SSH_SYSTEM_HOSTFILE);
+		stringlist_append(&hostkey_files, _PATH_SSH_SYSTEM_HOSTFILE2);
+	}
+	if (dest_constraint_strings != NULL) {
+		for (i = 0; dest_constraint_strings[i] != NULL; i++) {
+			parse_dest_constraint(dest_constraint_strings[i],
+			  &dest_constraints, &ndest_constraints, hostkey_files);
+		}
+	}
 
 	argc -= optind;
 	argv += optind;
@@ -804,14 +917,15 @@ main(int argc, char **argv)
 	}
 	if (pkcs11provider != NULL) {
 		if (update_card(agent_fd, !deleting, pkcs11provider,
-		    qflag) == -1)
+		    qflag, dest_constraints, ndest_constraints) == -1)
 			ret = 1;
 		goto done;
 	}
 	if (do_download) {
 		if (skprovider == NULL)
 			fatal("Cannot download keys without provider");
-		if (load_resident_keys(agent_fd, skprovider, qflag) != 0)
+		if (load_resident_keys(agent_fd, skprovider, qflag,
+		    dest_constraints, ndest_constraints) != 0)
 			ret = 1;
 		goto done;
 	}
@@ -834,7 +948,8 @@ main(int argc, char **argv)
 			if (stat(buf, &st) == -1)
 				continue;
 			if (do_file(agent_fd, deleting, key_only, buf,
-			    qflag, skprovider) == -1)
+			    qflag, skprovider,
+			    dest_constraints, ndest_constraints) == -1)
 				ret = 1;
 			else
 				count++;
@@ -844,7 +959,8 @@ main(int argc, char **argv)
 	} else {
 		for (i = 0; i < argc; i++) {
 			if (do_file(agent_fd, deleting, key_only,
-			    argv[i], qflag, skprovider) == -1)
+			    argv[i], qflag, skprovider,
+			    dest_constraints, ndest_constraints) == -1)
 				ret = 1;
 		}
 	}

--- a/ssh-add/Makefile
+++ b/ssh-add/Makefile
@@ -3,7 +3,7 @@
 .PATH:		${.CURDIR}/..
 
 SRCS=	ssh-add.c
-SRCS+=	authfd.c cleanup.c fatal.c readpass.c utf8.c
+SRCS+=	authfd.c cleanup.c fatal.c readpass.c utf8.c hostfile.c hmac.c
 SRCS+=	${SRCS_BASE} ${SRCS_KEY} ${SRCS_KEYP} ${SRCS_KRL} ${SRCS_UTL}
 SRCS+=	${SRCS_SK_CLIENT}
 

--- a/ssh-agent.c
+++ b/ssh-agent.c
@@ -280,22 +280,24 @@ agent_decode_alg(struct sshkey *key, u_int flags)
  * request, checking its contents for consistency and matching the embedded
  * key against the one that is being used for signing.
  * Note: does not modify msg buffer.
- * Optionally extract the username and session ID from the request.
+ * Optionally extract the username, session ID and/or hostkey from the request.
  */
 static int
 parse_userauth_request(struct sshbuf *msg, const struct sshkey *expected_key,
-    char **userp, struct sshbuf **sess_idp)
+    char **userp, struct sshbuf **sess_idp, struct sshkey **hostkeyp)
 {
 	struct sshbuf *b = NULL, *sess_id = NULL;
 	char *user = NULL, *service = NULL, *method = NULL, *pkalg = NULL;
 	int r;
 	u_char t, sig_follows;
-	struct sshkey *mkey = NULL;
+	struct sshkey *mkey = NULL, *hostkey = NULL;
 
 	if (userp != NULL)
 		*userp = NULL;
 	if (sess_idp != NULL)
 		*sess_idp = NULL;
+	if (hostkeyp != NULL)
+		*hostkeyp = NULL;
 	if ((b = sshbuf_fromb(msg)) == NULL)
 		fatal_f("sshbuf_fromb");
 
@@ -322,7 +324,10 @@ parse_userauth_request(struct sshbuf *msg, const struct sshkey *expected_key,
 		r = SSH_ERR_INVALID_FORMAT;
 		goto out;
 	}
-	if (strcmp(method, "publickey") != 0) {
+	if (strcmp(method, "publickey-hostbound-v00@openssh.com") == 0) {
+		if ((r = sshkey_froms(b, &hostkey)) != 0)
+			goto out;
+	} else if (strcmp(method, "publickey") != 0) {
 		r = SSH_ERR_INVALID_FORMAT;
 		goto out;
 	}
@@ -341,6 +346,10 @@ parse_userauth_request(struct sshbuf *msg, const struct sshkey *expected_key,
 		*sess_idp = sess_id;
 		sess_id = NULL;
 	}
+	if (hostkeyp != NULL) {
+		*hostkeyp = hostkey;
+		hostkey = NULL;
+	}
  out:
 	sshbuf_free(b);
 	sshbuf_free(sess_id);
@@ -349,6 +358,7 @@ parse_userauth_request(struct sshbuf *msg, const struct sshkey *expected_key,
 	free(method);
 	free(pkalg);
 	sshkey_free(mkey);
+	sshkey_free(hostkey);
 	return r;
 }
 
@@ -393,7 +403,7 @@ parse_sshsig_request(struct sshbuf *msg)
 static int
 check_websafe_message_contents(struct sshkey *key, struct sshbuf *data)
 {
-	if (parse_userauth_request(data, key, NULL, NULL) == 0) {
+	if (parse_userauth_request(data, key, NULL, NULL, NULL) == 0) {
 		debug_f("signed data matches public key userauth request");
 		return 1;
 	}

--- a/sshconnect.c
+++ b/sshconnect.c
@@ -1662,7 +1662,7 @@ maybe_add_key_to_agent(const char *authfile, struct sshkey *private,
 	if ((r = ssh_add_identity_constrained(auth_sock, private,
 	    comment == NULL ? authfile : comment,
 	    options.add_keys_to_agent_lifespan,
-	    (options.add_keys_to_agent == 3), 0, skprovider)) == 0)
+	    (options.add_keys_to_agent == 3), 0, skprovider, NULL, 0)) == 0)
 		debug("identity added to agent: %s", authfile);
 	else
 		debug("could not add identity to agent: %s (%d)", authfile, r);

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -1337,7 +1337,11 @@ sign_and_send_pubkey(struct ssh *ssh, Identity *id)
 	size_t slen = 0, skip = 0;
 	int r, fallback_sigtype, sent = 0;
 	char *alg = NULL, *fp = NULL;
-	const char *loc = "";
+	const char *loc = "", *method = "publickey";
+
+	/* prefer host-bound pubkey signatures if supported by server */
+	if ((ssh->kex->flags & KEX_HAS_PUBKEY_HOSTBOUND) != 0)
+		method = "publickey-hostbound-v00@openssh.com";
 
 	if ((fp = sshkey_fingerprint(id->key, options.fingerprint_hash,
 	    SSH_FP_DEFAULT)) == NULL)
@@ -1423,13 +1427,20 @@ sign_and_send_pubkey(struct ssh *ssh, Identity *id)
 		if ((r = sshbuf_put_u8(b, SSH2_MSG_USERAUTH_REQUEST)) != 0 ||
 		    (r = sshbuf_put_cstring(b, authctxt->server_user)) != 0 ||
 		    (r = sshbuf_put_cstring(b, authctxt->service)) != 0 ||
-		    (r = sshbuf_put_cstring(b, authctxt->method->name)) != 0 ||
+		    (r = sshbuf_put_cstring(b, method)) != 0 ||
 		    (r = sshbuf_put_u8(b, 1)) != 0 ||
 		    (r = sshbuf_put_cstring(b, alg)) != 0 ||
 		    (r = sshkey_puts(id->key, b)) != 0) {
 			fatal_fr(r, "assemble signed data");
 		}
-
+		if ((ssh->kex->flags & KEX_HAS_PUBKEY_HOSTBOUND) != 0) {
+			if (ssh->kex->initial_hostkey == NULL) {
+				fatal_f("internal error: initial hostkey "
+				    "not recorded");
+			}
+			if ((r = sshkey_puts(ssh->kex->initial_hostkey, b)) != 0)
+				fatal_fr(r, "assemble %s hostkey", method);
+		}
 		/* generate signature */
 		r = identity_sign(sign_id, &signature, &slen,
 		    sshbuf_ptr(b), sshbuf_len(b), ssh->compat, alg);

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -1340,7 +1340,8 @@ sign_and_send_pubkey(struct ssh *ssh, Identity *id)
 	const char *loc = "", *method = "publickey";
 
 	/* prefer host-bound pubkey signatures if supported by server */
-	if ((ssh->kex->flags & KEX_HAS_PUBKEY_HOSTBOUND) != 0)
+	if ((ssh->kex->flags & KEX_HAS_PUBKEY_HOSTBOUND) != 0 &&
+	    (options.pubkey_authentication & SSH_PUBKEY_AUTH_HBIND) != 0)
 		method = "publickey-hostbound-v00@openssh.com";
 
 	if ((fp = sshkey_fingerprint(id->key, options.fingerprint_hash,


### PR DESCRIPTION
**NB. documentation incomplete**

This is another approach to providing a better permission model to the agent-binding proposal at https://github.com/djmdjm/openssh-wip/pull/3

This approach introduces a modified `publickey-hostbound-v00@openssh.com` public key authentication method. This method  that includes the hostkey offered by the server during initial KEX in the data that is signed by the client and verified by the server. A modified `ssh-agent` can parse the data it is signing and extract this hostkey and the username.

`ssh-agent` is modified to support a basic per-key permission model. Keys may have *destination constraints* attached that specify `[user@]hostkey` tuples where the key is allowed to be used.

`ssh-add` gains the ability to set these constraints when adding keys to an agent, in the more user-friendly form of `[user]@hostname`. Host keys are looked up from these hostnames in the usual `known_hosts` file.

This approach avoids an attack in the agent-binding approach where a attacker on a hop and use that hop's hostkey to sign another host's session IDs (thanks Jann Horn).

Downside of this approach is that no path information is available at the agent for decision-making. Also, this approach requires all servers support the new pubkey authentication method.

IMO a hybrid approach is probably best: this approach gives strong binding between signatures and hostkeys, but retaining the session binding allows the origin to make connections to servers that lack extension support and also allows the agent to make decisions based on forwarding path rather than just destinations.

The two approaches could be combined by using session-binding for the initial hop (it's trustworthy there and it removes the need to servers to support the host-bound pubkey method) and then by-default requiring host-bound signatures for subsequent hops (thereby maintaining integrity of the destination signifier). 

Probably need a better permission model in any case though - perhaps specifying authentication **paths** rather than **destinations**. E.g. permitting `hostA->hostB->hostC, hostE->hostF` and banning cycles like `hostA->hostB->hostB` unless the user explicitly requested them.