### PR TITLE
Refactor sshkey

### DIFF
--- a/ssh-dss.c
+++ b/ssh-dss.c
@@ -96,7 +96,7 @@ ssh_dss_equal(const struct sshkey *a, const struct sshkey *b)
 
 static int
 ssh_dss_serialize_public(const struct sshkey *key, struct sshbuf *b,
-    const char *typename, enum sshkey_serialize_rep opts)
+    enum sshkey_serialize_rep opts)
 {
 	int r;
 	const BIGNUM *dsa_p, *dsa_q, *dsa_g, *dsa_pub_key;
@@ -108,8 +108,7 @@ ssh_dss_serialize_public(const struct sshkey *key, struct sshbuf *b,
 	if (dsa_p == NULL || dsa_q == NULL ||
 	    dsa_g == NULL || dsa_pub_key == NULL)
 		return SSH_ERR_INTERNAL_ERROR;
-	if ((r = sshbuf_put_cstring(b, typename)) != 0 ||
-	    (r = sshbuf_put_bignum2(b, dsa_p)) != 0 ||
+	if ((r = sshbuf_put_bignum2(b, dsa_p)) != 0 ||
 	    (r = sshbuf_put_bignum2(b, dsa_q)) != 0 ||
 	    (r = sshbuf_put_bignum2(b, dsa_g)) != 0 ||
 	    (r = sshbuf_put_bignum2(b, dsa_pub_key)) != 0)
@@ -171,6 +170,43 @@ ssh_dss_copy_public(const struct sshkey *from, struct sshkey *to)
 	BN_clear_free(dsa_g_dup);
 	BN_clear_free(dsa_pub_key_dup);
 	return r;
+}
+
+static int
+ssh_dss_deserialize_public(const char *ktype, struct sshbuf *b,
+    struct sshkey *key)
+{
+	int ret = SSH_ERR_INTERNAL_ERROR;
+	BIGNUM *dsa_p = NULL, *dsa_q = NULL, *dsa_g = NULL, *dsa_pub_key = NULL;
+
+	if (sshbuf_get_bignum2(b, &dsa_p) != 0 ||
+	    sshbuf_get_bignum2(b, &dsa_q) != 0 ||
+	    sshbuf_get_bignum2(b, &dsa_g) != 0 ||
+	    sshbuf_get_bignum2(b, &dsa_pub_key) != 0) {
+		ret = SSH_ERR_INVALID_FORMAT;
+		goto out;
+	}
+	if (!DSA_set0_pqg(key->dsa, dsa_p, dsa_q, dsa_g)) {
+		ret = SSH_ERR_LIBCRYPTO_ERROR;
+		goto out;
+	}
+	dsa_p = dsa_q = dsa_g = NULL; /* transferred */
+	if (!DSA_set0_key(key->dsa, dsa_pub_key, NULL)) {
+		ret = SSH_ERR_LIBCRYPTO_ERROR;
+		goto out;
+	}
+	dsa_pub_key = NULL; /* transferred */
+#ifdef DEBUG_PK
+	DSA_print_fp(stderr, key->dsa, 8);
+#endif
+	/* success */
+	ret = 0;
+ out:
+	BN_clear_free(dsa_p);
+	BN_clear_free(dsa_q);
+	BN_clear_free(dsa_g);
+	BN_clear_free(dsa_pub_key);
+	return ret;
 }
 
 int
@@ -336,6 +372,7 @@ static const struct sshkey_impl_funcs sshkey_dss_funcs = {
 	/* .cleanup = */	ssh_dss_cleanup,
 	/* .equal = */		ssh_dss_equal,
 	/* .ssh_serialize_public = */ ssh_dss_serialize_public,
+	/* .ssh_deserialize_public = */ ssh_dss_deserialize_public,
 	/* .generate = */	ssh_dss_generate,
 	/* .copy_public = */	ssh_dss_copy_public,
 };

--- a/ssh-dss.c
+++ b/ssh-dss.c
@@ -209,9 +209,11 @@ ssh_dss_deserialize_public(const char *ktype, struct sshbuf *b,
 	return ret;
 }
 
-int
-ssh_dss_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
-    const u_char *data, size_t datalen, u_int compat)
+static int
+ssh_dss_sign(struct sshkey *key,
+    u_char **sigp, size_t *lenp,
+    const u_char *data, size_t datalen,
+    const char *alg, const char *sk_provider, const char *sk_pin, u_int compat)
 {
 	DSA_SIG *sig = NULL;
 	const BIGNUM *sig_r, *sig_s;
@@ -277,28 +279,29 @@ ssh_dss_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
 	return ret;
 }
 
-int
+static int
 ssh_dss_verify(const struct sshkey *key,
-    const u_char *signature, size_t signaturelen,
-    const u_char *data, size_t datalen, u_int compat)
+    const u_char *sig, size_t siglen,
+    const u_char *data, size_t dlen, const char *alg, u_int compat,
+    struct sshkey_sig_details **detailsp)
 {
-	DSA_SIG *sig = NULL;
+	DSA_SIG *dsig = NULL;
 	BIGNUM *sig_r = NULL, *sig_s = NULL;
 	u_char digest[SSH_DIGEST_MAX_LENGTH], *sigblob = NULL;
-	size_t len, dlen = ssh_digest_bytes(SSH_DIGEST_SHA1);
+	size_t len, hlen = ssh_digest_bytes(SSH_DIGEST_SHA1);
 	int ret = SSH_ERR_INTERNAL_ERROR;
 	struct sshbuf *b = NULL;
 	char *ktype = NULL;
 
 	if (key == NULL || key->dsa == NULL ||
 	    sshkey_type_plain(key->type) != KEY_DSA ||
-	    signature == NULL || signaturelen == 0)
+	    sig == NULL || siglen == 0)
 		return SSH_ERR_INVALID_ARGUMENT;
-	if (dlen == 0)
+	if (hlen == 0)
 		return SSH_ERR_INTERNAL_ERROR;
 
 	/* fetch signature */
-	if ((b = sshbuf_from(signature, signaturelen)) == NULL)
+	if ((b = sshbuf_from(sig, siglen)) == NULL)
 		return SSH_ERR_ALLOC_FAIL;
 	if (sshbuf_get_cstring(b, &ktype, NULL) != 0 ||
 	    sshbuf_get_string(b, &sigblob, &len) != 0) {
@@ -320,7 +323,7 @@ ssh_dss_verify(const struct sshkey *key,
 	}
 
 	/* parse signature */
-	if ((sig = DSA_SIG_new()) == NULL ||
+	if ((dsig = DSA_SIG_new()) == NULL ||
 	    (sig_r = BN_new()) == NULL ||
 	    (sig_s = BN_new()) == NULL) {
 		ret = SSH_ERR_ALLOC_FAIL;
@@ -331,18 +334,18 @@ ssh_dss_verify(const struct sshkey *key,
 		ret = SSH_ERR_LIBCRYPTO_ERROR;
 		goto out;
 	}
-	if (!DSA_SIG_set0(sig, sig_r, sig_s)) {
+	if (!DSA_SIG_set0(dsig, sig_r, sig_s)) {
 		ret = SSH_ERR_LIBCRYPTO_ERROR;
 		goto out;
 	}
 	sig_r = sig_s = NULL; /* transferred */
 
 	/* sha1 the data */
-	if ((ret = ssh_digest_memory(SSH_DIGEST_SHA1, data, datalen,
+	if ((ret = ssh_digest_memory(SSH_DIGEST_SHA1, data, dlen,
 	    digest, sizeof(digest))) != 0)
 		goto out;
 
-	switch (DSA_do_verify(digest, dlen, sig, key->dsa)) {
+	switch (DSA_do_verify(digest, hlen, dsig, key->dsa)) {
 	case 1:
 		ret = 0;
 		break;
@@ -356,7 +359,7 @@ ssh_dss_verify(const struct sshkey *key,
 
  out:
 	explicit_bzero(digest, sizeof(digest));
-	DSA_SIG_free(sig);
+	DSA_SIG_free(dsig);
 	BN_clear_free(sig_r);
 	BN_clear_free(sig_s);
 	sshbuf_free(b);
@@ -375,6 +378,8 @@ static const struct sshkey_impl_funcs sshkey_dss_funcs = {
 	/* .ssh_deserialize_public = */ ssh_dss_deserialize_public,
 	/* .generate = */	ssh_dss_generate,
 	/* .copy_public = */	ssh_dss_copy_public,
+	/* .sign = */		ssh_dss_sign,
+	/* .verify = */		ssh_dss_verify,
 };
 
 const struct sshkey_impl sshkey_dss_impl = {

--- a/ssh-dss.c
+++ b/ssh-dss.c
@@ -136,6 +136,43 @@ ssh_dss_generate(struct sshkey *k, int bits)
 	return 0;
 }
 
+static int
+ssh_dss_copy_public(const struct sshkey *from, struct sshkey *to)
+{
+	const BIGNUM *dsa_p, *dsa_q, *dsa_g, *dsa_pub_key;
+	BIGNUM *dsa_p_dup = NULL, *dsa_q_dup = NULL, *dsa_g_dup = NULL;
+	BIGNUM *dsa_pub_key_dup = NULL;
+	int r = SSH_ERR_INTERNAL_ERROR;
+
+	DSA_get0_pqg(from->dsa, &dsa_p, &dsa_q, &dsa_g);
+	DSA_get0_key(from->dsa, &dsa_pub_key, NULL);
+	if ((dsa_p_dup = BN_dup(dsa_p)) == NULL ||
+	    (dsa_q_dup = BN_dup(dsa_q)) == NULL ||
+	    (dsa_g_dup = BN_dup(dsa_g)) == NULL ||
+	    (dsa_pub_key_dup = BN_dup(dsa_pub_key)) == NULL) {
+		r = SSH_ERR_ALLOC_FAIL;
+		goto out;
+	}
+	if (!DSA_set0_pqg(to->dsa, dsa_p_dup, dsa_q_dup, dsa_g_dup)) {
+		r = SSH_ERR_LIBCRYPTO_ERROR;
+		goto out;
+	}
+	dsa_p_dup = dsa_q_dup = dsa_g_dup = NULL; /* transferred */
+	if (!DSA_set0_key(to->dsa, dsa_pub_key_dup, NULL)) {
+		r = SSH_ERR_LIBCRYPTO_ERROR;
+		goto out;
+	}
+	dsa_pub_key_dup = NULL; /* transferred */
+	/* success */
+	r = 0;
+ out:
+	BN_clear_free(dsa_p_dup);
+	BN_clear_free(dsa_q_dup);
+	BN_clear_free(dsa_g_dup);
+	BN_clear_free(dsa_pub_key_dup);
+	return r;
+}
+
 int
 ssh_dss_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen, u_int compat)
@@ -300,6 +337,7 @@ static const struct sshkey_impl_funcs sshkey_dss_funcs = {
 	/* .equal = */		ssh_dss_equal,
 	/* .ssh_serialize_public = */ ssh_dss_serialize_public,
 	/* .generate = */	ssh_dss_generate,
+	/* .copy_public = */	ssh_dss_copy_public,
 };
 
 const struct sshkey_impl sshkey_dss_impl = {

--- a/ssh-dss.c
+++ b/ssh-dss.c
@@ -228,6 +228,27 @@ ssh_dss_deserialize_public(const char *ktype, struct sshbuf *b,
 }
 
 static int
+ssh_dss_deserialize_private(const char *ktype, struct sshbuf *b,
+    struct sshkey *key)
+{
+	int r;
+	BIGNUM *dsa_priv_key = NULL;
+
+	if (!sshkey_is_cert(key)) {
+		if ((r = ssh_dss_deserialize_public(ktype, b, key)) != 0)
+			return r;
+	}
+
+	if ((r = sshbuf_get_bignum2(b, &dsa_priv_key)) != 0)
+		return r;
+	if (!DSA_set0_key(key->dsa, NULL, dsa_priv_key)) {
+		BN_clear_free(dsa_priv_key);
+		return SSH_ERR_LIBCRYPTO_ERROR;
+	}
+	return 0;
+}
+
+static int
 ssh_dss_sign(struct sshkey *key,
     u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen,
@@ -395,6 +416,7 @@ static const struct sshkey_impl_funcs sshkey_dss_funcs = {
 	/* .ssh_serialize_public = */ ssh_dss_serialize_public,
 	/* .ssh_deserialize_public = */ ssh_dss_deserialize_public,
 	/* .ssh_serialize_private = */ ssh_dss_serialize_private,
+	/* .ssh_deserialize_private = */ ssh_dss_deserialize_private,
 	/* .generate = */	ssh_dss_generate,
 	/* .copy_public = */	ssh_dss_copy_public,
 	/* .sign = */		ssh_dss_sign,

--- a/ssh-dss.c
+++ b/ssh-dss.c
@@ -40,6 +40,32 @@
 #define INTBLOB_LEN	20
 #define SIGBLOB_LEN	(2*INTBLOB_LEN)
 
+static u_int
+ssh_dss_size(const struct sshkey *key)
+{
+	const BIGNUM *dsa_p;
+
+	if (key->dsa == NULL)
+		return 0;
+	DSA_get0_pqg(key->dsa, &dsa_p, NULL, NULL);
+	return BN_num_bits(dsa_p);
+}
+
+static int
+ssh_dss_alloc(struct sshkey *k)
+{
+	if ((k->dsa = DSA_new()) == NULL)
+		return SSH_ERR_ALLOC_FAIL;
+	return 0;
+}
+
+static void
+ssh_dss_cleanup(struct sshkey *k)
+{
+	DSA_free(k->dsa);
+	k->dsa = NULL;
+}
+
 int
 ssh_dss_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen, u_int compat)
@@ -196,3 +222,33 @@ ssh_dss_verify(const struct sshkey *key,
 		freezero(sigblob, len);
 	return ret;
 }
+
+static const struct sshkey_impl_funcs sshkey_dss_funcs = {
+	/* .size = */		ssh_dss_size,
+	/* .alloc = */		ssh_dss_alloc,
+	/* .cleanup = */	ssh_dss_cleanup,
+};
+
+const struct sshkey_impl sshkey_dss_impl = {
+	/* .name = */		"ssh-dss",
+	/* .shortname = */	"DSA",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_DSA,
+	/* .nid = */		0,
+	/* .cert = */		0,
+	/* .sigonly = */	0,
+	/* .keybits = */	0,
+	/* .funcs = */		&sshkey_dss_funcs,
+};
+
+const struct sshkey_impl sshkey_dsa_cert_impl = {
+	/* .name = */		"ssh-dss-cert-v01@openssh.com",
+	/* .shortname = */	"DSA-CERT",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_DSA_CERT,
+	/* .nid = */		0,
+	/* .cert = */		1,
+	/* .sigonly = */	0,
+	/* .keybits = */	0,
+	/* .funcs = */		&sshkey_dss_funcs,
+};

--- a/ssh-dss.c
+++ b/ssh-dss.c
@@ -118,6 +118,24 @@ ssh_dss_serialize_public(const struct sshkey *key, struct sshbuf *b,
 }
 
 static int
+ssh_dss_serialize_private(const struct sshkey *key, struct sshbuf *b,
+    enum sshkey_serialize_rep opts)
+{
+	int r;
+	const BIGNUM *dsa_priv_key;
+
+	DSA_get0_key(key->dsa, NULL, &dsa_priv_key);
+	if (!sshkey_is_cert(key)) {
+		if ((r = ssh_dss_serialize_public(key, b, opts)) != 0)
+			return r;
+	}
+	if ((r = sshbuf_put_bignum2(b, dsa_priv_key)) != 0)
+		return r;
+
+	return 0;
+}
+
+static int
 ssh_dss_generate(struct sshkey *k, int bits)
 {
 	DSA *private;
@@ -376,6 +394,7 @@ static const struct sshkey_impl_funcs sshkey_dss_funcs = {
 	/* .equal = */		ssh_dss_equal,
 	/* .ssh_serialize_public = */ ssh_dss_serialize_public,
 	/* .ssh_deserialize_public = */ ssh_dss_deserialize_public,
+	/* .ssh_serialize_private = */ ssh_dss_serialize_private,
 	/* .generate = */	ssh_dss_generate,
 	/* .copy_public = */	ssh_dss_copy_public,
 	/* .sign = */		ssh_dss_sign,

--- a/ssh-dss.c
+++ b/ssh-dss.c
@@ -94,6 +94,30 @@ ssh_dss_equal(const struct sshkey *a, const struct sshkey *b)
 	return 1;
 }
 
+static int
+ssh_dss_serialize_public(const struct sshkey *key, struct sshbuf *b,
+    const char *typename, enum sshkey_serialize_rep opts)
+{
+	int r;
+	const BIGNUM *dsa_p, *dsa_q, *dsa_g, *dsa_pub_key;
+
+	if (key->dsa == NULL)
+		return SSH_ERR_INVALID_ARGUMENT;
+	DSA_get0_pqg(key->dsa, &dsa_p, &dsa_q, &dsa_g);
+	DSA_get0_key(key->dsa, &dsa_pub_key, NULL);
+	if (dsa_p == NULL || dsa_q == NULL ||
+	    dsa_g == NULL || dsa_pub_key == NULL)
+		return SSH_ERR_INTERNAL_ERROR;
+	if ((r = sshbuf_put_cstring(b, typename)) != 0 ||
+	    (r = sshbuf_put_bignum2(b, dsa_p)) != 0 ||
+	    (r = sshbuf_put_bignum2(b, dsa_q)) != 0 ||
+	    (r = sshbuf_put_bignum2(b, dsa_g)) != 0 ||
+	    (r = sshbuf_put_bignum2(b, dsa_pub_key)) != 0)
+		return r;
+
+	return 0;
+}
+
 int
 ssh_dss_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen, u_int compat)
@@ -256,6 +280,7 @@ static const struct sshkey_impl_funcs sshkey_dss_funcs = {
 	/* .alloc = */		ssh_dss_alloc,
 	/* .cleanup = */	ssh_dss_cleanup,
 	/* .equal = */		ssh_dss_equal,
+	/* .ssh_serialize_public = */ ssh_dss_serialize_public,
 };
 
 const struct sshkey_impl sshkey_dss_impl = {

--- a/ssh-dss.c
+++ b/ssh-dss.c
@@ -66,6 +66,34 @@ ssh_dss_cleanup(struct sshkey *k)
 	k->dsa = NULL;
 }
 
+static int
+ssh_dss_equal(const struct sshkey *a, const struct sshkey *b)
+{
+	const BIGNUM *dsa_p_a, *dsa_q_a, *dsa_g_a, *dsa_pub_key_a;
+	const BIGNUM *dsa_p_b, *dsa_q_b, *dsa_g_b, *dsa_pub_key_b;
+
+	if (a->dsa == NULL || b->dsa == NULL)
+		return 0;
+	DSA_get0_pqg(a->dsa, &dsa_p_a, &dsa_q_a, &dsa_g_a);
+	DSA_get0_pqg(b->dsa, &dsa_p_b, &dsa_q_b, &dsa_g_b);
+	DSA_get0_key(a->dsa, &dsa_pub_key_a, NULL);
+	DSA_get0_key(b->dsa, &dsa_pub_key_b, NULL);
+	if (dsa_p_a == NULL || dsa_p_b == NULL ||
+	    dsa_q_a == NULL || dsa_q_b == NULL ||
+	    dsa_g_a == NULL || dsa_g_b == NULL ||
+	    dsa_pub_key_a == NULL || dsa_pub_key_b == NULL)
+		return 0;
+	if (BN_cmp(dsa_p_a, dsa_p_b) != 0)
+		return 0;
+	if (BN_cmp(dsa_q_a, dsa_q_b) != 0)
+		return 0;
+	if (BN_cmp(dsa_g_a, dsa_g_b) != 0)
+		return 0;
+	if (BN_cmp(dsa_pub_key_a, dsa_pub_key_b) != 0)
+		return 0;
+	return 1;
+}
+
 int
 ssh_dss_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen, u_int compat)
@@ -227,6 +255,7 @@ static const struct sshkey_impl_funcs sshkey_dss_funcs = {
 	/* .size = */		ssh_dss_size,
 	/* .alloc = */		ssh_dss_alloc,
 	/* .cleanup = */	ssh_dss_cleanup,
+	/* .equal = */		ssh_dss_equal,
 };
 
 const struct sshkey_impl sshkey_dss_impl = {

--- a/ssh-ecdsa-sk.c
+++ b/ssh-ecdsa-sk.c
@@ -344,6 +344,7 @@ static const struct sshkey_impl_funcs sshkey_ecdsa_sk_funcs = {
 	/* .cleanup = */	ssh_ecdsa_sk_cleanup,
 	/* .equal = */		ssh_ecdsa_sk_equal,
 	/* .ssh_serialize_public = */ ssh_ecdsa_sk_serialize_public,
+	/* .generate = */	NULL,
 };
 
 const struct sshkey_impl sshkey_ecdsa_sk_impl = {

--- a/ssh-ecdsa-sk.c
+++ b/ssh-ecdsa-sk.c
@@ -63,6 +63,21 @@ ssh_ecdsa_sk_equal(const struct sshkey *a, const struct sshkey *b)
 	return 1;
 }
 
+static int
+ssh_ecdsa_sk_serialize_public(const struct sshkey *key, struct sshbuf *b,
+    const char *typename, enum sshkey_serialize_rep opts)
+{
+	int r;
+
+	if ((r = sshkey_ecdsa_funcs.serialize_public(key, b,
+	    typename, opts)) != 0)
+		return r;
+	if ((r = sshkey_serialize_sk(key, b)) != 0)
+		return r;
+
+	return 0;
+}
+
 /*
  * Check FIDO/W3C webauthn signatures clientData field against the expected
  * format and prepare a hash of it for use in signature verification.
@@ -328,6 +343,7 @@ static const struct sshkey_impl_funcs sshkey_ecdsa_sk_funcs = {
 	/* .alloc = */		NULL,
 	/* .cleanup = */	ssh_ecdsa_sk_cleanup,
 	/* .equal = */		ssh_ecdsa_sk_equal,
+	/* .ssh_serialize_public = */ ssh_ecdsa_sk_serialize_public,
 };
 
 const struct sshkey_impl sshkey_ecdsa_sk_impl = {

--- a/ssh-ecdsa-sk.c
+++ b/ssh-ecdsa-sk.c
@@ -78,6 +78,18 @@ ssh_ecdsa_sk_serialize_public(const struct sshkey *key, struct sshbuf *b,
 	return 0;
 }
 
+static int
+ssh_ecdsa_sk_copy_public(const struct sshkey *from, struct sshkey *to)
+{
+	int r;
+
+	if ((r = sshkey_ecdsa_funcs.copy_public(from, to)) != 0)
+		return r;
+	if ((r = sshkey_copy_public_sk(from, to)) != 0)
+		return r;
+	return 0;
+}
+
 /*
  * Check FIDO/W3C webauthn signatures clientData field against the expected
  * format and prepare a hash of it for use in signature verification.
@@ -345,6 +357,7 @@ static const struct sshkey_impl_funcs sshkey_ecdsa_sk_funcs = {
 	/* .equal = */		ssh_ecdsa_sk_equal,
 	/* .ssh_serialize_public = */ ssh_ecdsa_sk_serialize_public,
 	/* .generate = */	NULL,
+	/* .copy_public = */	ssh_ecdsa_sk_copy_public,
 };
 
 const struct sshkey_impl sshkey_ecdsa_sk_impl = {

--- a/ssh-ecdsa-sk.c
+++ b/ssh-ecdsa-sk.c
@@ -65,12 +65,11 @@ ssh_ecdsa_sk_equal(const struct sshkey *a, const struct sshkey *b)
 
 static int
 ssh_ecdsa_sk_serialize_public(const struct sshkey *key, struct sshbuf *b,
-    const char *typename, enum sshkey_serialize_rep opts)
+    enum sshkey_serialize_rep opts)
 {
 	int r;
 
-	if ((r = sshkey_ecdsa_funcs.serialize_public(key, b,
-	    typename, opts)) != 0)
+	if ((r = sshkey_ecdsa_funcs.serialize_public(key, b, opts)) != 0)
 		return r;
 	if ((r = sshkey_serialize_sk(key, b)) != 0)
 		return r;
@@ -86,6 +85,19 @@ ssh_ecdsa_sk_copy_public(const struct sshkey *from, struct sshkey *to)
 	if ((r = sshkey_ecdsa_funcs.copy_public(from, to)) != 0)
 		return r;
 	if ((r = sshkey_copy_public_sk(from, to)) != 0)
+		return r;
+	return 0;
+}
+
+static int
+ssh_ecdsa_sk_deserialize_public(const char *ktype, struct sshbuf *b,
+    struct sshkey *key)
+{
+	int r;
+
+	if ((r = sshkey_ecdsa_funcs.deserialize_public(ktype, b, key)) != 0)
+		return r;
+	if ((r = sshkey_deserialize_sk(b, key)) != 0)
 		return r;
 	return 0;
 }
@@ -356,6 +368,7 @@ static const struct sshkey_impl_funcs sshkey_ecdsa_sk_funcs = {
 	/* .cleanup = */	ssh_ecdsa_sk_cleanup,
 	/* .equal = */		ssh_ecdsa_sk_equal,
 	/* .ssh_serialize_public = */ ssh_ecdsa_sk_serialize_public,
+	/* .ssh_deserialize_public = */ ssh_ecdsa_sk_deserialize_public,
 	/* .generate = */	NULL,
 	/* .copy_public = */	ssh_ecdsa_sk_copy_public,
 };

--- a/ssh-ecdsa-sk.c
+++ b/ssh-ecdsa-sk.c
@@ -43,6 +43,16 @@
 #define SSHKEY_INTERNAL
 #include "sshkey.h"
 
+static void
+ssh_ecdsa_sk_cleanup(struct sshkey *k)
+{
+	free(k->sk_application);
+	sshbuf_free(k->sk_key_handle);
+	sshbuf_free(k->sk_reserved);
+	EC_KEY_free(k->ecdsa);
+	k->ecdsa = NULL;
+}
+
 /*
  * Check FIDO/W3C webauthn signatures clientData field against the expected
  * format and prepare a hash of it for use in signature verification.
@@ -302,3 +312,45 @@ ssh_ecdsa_sk_verify(const struct sshkey *key,
 	free(ktype);
 	return ret;
 }
+
+static const struct sshkey_impl_funcs sshkey_ecdsa_sk_funcs = {
+	/* .size = */		NULL,
+	/* .alloc = */		NULL,
+	/* .cleanup = */	ssh_ecdsa_sk_cleanup,
+};
+
+const struct sshkey_impl sshkey_ecdsa_sk_impl = {
+	/* .name = */		"sk-ecdsa-sha2-nistp256@openssh.com",
+	/* .shortname = */	"ECDSA-SK",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_ECDSA_SK,
+	/* .nid = */		NID_X9_62_prime256v1,
+	/* .cert = */		0,
+	/* .sigonly = */	0,
+	/* .keybits = */	256,
+	/* .funcs = */		&sshkey_ecdsa_sk_funcs,
+};
+
+const struct sshkey_impl sshkey_ecdsa_sk_cert_impl = {
+	/* .name = */		"sk-ecdsa-sha2-nistp256-cert-v01@openssh.com",
+	/* .shortname = */	"ECDSA-SK-CERT",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_ECDSA_SK_CERT,
+	/* .nid = */		NID_X9_62_prime256v1,
+	/* .cert = */		1,
+	/* .sigonly = */	0,
+	/* .keybits = */	256,
+	/* .funcs = */		&sshkey_ecdsa_sk_funcs,
+};
+
+const struct sshkey_impl sshkey_ecdsa_sk_webauthn_impl = {
+	/* .name = */		"webauthn-sk-ecdsa-sha2-nistp256@openssh.com",
+	/* .shortname = */	"ECDSA-SK",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_ECDSA_SK,
+	/* .nid = */		NID_X9_62_prime256v1,
+	/* .cert = */		0,
+	/* .sigonly = */	1,
+	/* .keybits = */	256,
+	/* .funcs = */		&sshkey_ecdsa_sk_funcs,
+};

--- a/ssh-ecdsa-sk.c
+++ b/ssh-ecdsa-sk.c
@@ -119,6 +119,23 @@ ssh_ecdsa_sk_deserialize_public(const char *ktype, struct sshbuf *b,
 	return 0;
 }
 
+static int
+ssh_ecdsa_sk_deserialize_private(const char *ktype, struct sshbuf *b,
+    struct sshkey *key)
+{
+	int r;
+
+	if (!sshkey_is_cert(key)) {
+		if ((r = sshkey_ecdsa_funcs.deserialize_public(ktype,
+		    b, key)) != 0)
+			return r;
+	}
+	if ((r = sshkey_private_deserialize_sk(b, key)) != 0)
+		return r;
+
+	return 0;
+}
+
 /*
  * Check FIDO/W3C webauthn signatures clientData field against the expected
  * format and prepare a hash of it for use in signature verification.
@@ -387,6 +404,7 @@ static const struct sshkey_impl_funcs sshkey_ecdsa_sk_funcs = {
 	/* .ssh_serialize_public = */ ssh_ecdsa_sk_serialize_public,
 	/* .ssh_deserialize_public = */ ssh_ecdsa_sk_deserialize_public,
 	/* .ssh_serialize_private = */ ssh_ecdsa_sk_serialize_private,
+	/* .ssh_deserialize_private = */ ssh_ecdsa_sk_deserialize_private,
 	/* .generate = */	NULL,
 	/* .copy_public = */	ssh_ecdsa_sk_copy_public,
 	/* .sign = */		NULL,

--- a/ssh-ecdsa-sk.c
+++ b/ssh-ecdsa-sk.c
@@ -78,6 +78,23 @@ ssh_ecdsa_sk_serialize_public(const struct sshkey *key, struct sshbuf *b,
 }
 
 static int
+ssh_ecdsa_sk_serialize_private(const struct sshkey *key, struct sshbuf *b,
+    enum sshkey_serialize_rep opts)
+{
+	int r;
+
+	if (!sshkey_is_cert(key)) {
+		if ((r = sshkey_ecdsa_funcs.serialize_public(key,
+		    b, opts)) != 0)
+			return r;
+	}
+	if ((r = sshkey_serialize_private_sk(key, b)) != 0)
+		return r;
+
+	return 0;
+}
+
+static int
 ssh_ecdsa_sk_copy_public(const struct sshkey *from, struct sshkey *to)
 {
 	int r;
@@ -369,6 +386,7 @@ static const struct sshkey_impl_funcs sshkey_ecdsa_sk_funcs = {
 	/* .equal = */		ssh_ecdsa_sk_equal,
 	/* .ssh_serialize_public = */ ssh_ecdsa_sk_serialize_public,
 	/* .ssh_deserialize_public = */ ssh_ecdsa_sk_deserialize_public,
+	/* .ssh_serialize_private = */ ssh_ecdsa_sk_serialize_private,
 	/* .generate = */	NULL,
 	/* .copy_public = */	ssh_ecdsa_sk_copy_public,
 	/* .sign = */		NULL,

--- a/ssh-ecdsa-sk.c
+++ b/ssh-ecdsa-sk.c
@@ -179,13 +179,13 @@ webauthn_check_prepare_hash(const u_char *data, size_t datalen,
 }
 
 /* ARGSUSED */
-int
+static int
 ssh_ecdsa_sk_verify(const struct sshkey *key,
-    const u_char *signature, size_t signaturelen,
-    const u_char *data, size_t datalen, u_int compat,
+    const u_char *sig, size_t siglen,
+    const u_char *data, size_t dlen, const char *alg, u_int compat,
     struct sshkey_sig_details **detailsp)
 {
-	ECDSA_SIG *sig = NULL;
+	ECDSA_SIG *esig = NULL;
 	BIGNUM *sig_r = NULL, *sig_s = NULL;
 	u_char sig_flags;
 	u_char msghash[32], apphash[32], sighash[32];
@@ -203,14 +203,14 @@ ssh_ecdsa_sk_verify(const struct sshkey *key,
 		*detailsp = NULL;
 	if (key == NULL || key->ecdsa == NULL ||
 	    sshkey_type_plain(key->type) != KEY_ECDSA_SK ||
-	    signature == NULL || signaturelen == 0)
+	    sig == NULL || siglen == 0)
 		return SSH_ERR_INVALID_ARGUMENT;
 
 	if (key->ecdsa_nid != NID_X9_62_prime256v1)
 		return SSH_ERR_INTERNAL_ERROR;
 
 	/* fetch signature */
-	if ((b = sshbuf_from(signature, signaturelen)) == NULL)
+	if ((b = sshbuf_from(sig, siglen)) == NULL)
 		return SSH_ERR_ALLOC_FAIL;
 	if ((details = calloc(1, sizeof(*details))) == NULL) {
 		ret = SSH_ERR_ALLOC_FAIL;
@@ -272,11 +272,11 @@ ssh_ecdsa_sk_verify(const struct sshkey *key,
 		sshbuf_dump(webauthn_wrapper, stderr);
 	}
 #endif
-	if ((sig = ECDSA_SIG_new()) == NULL) {
+	if ((esig = ECDSA_SIG_new()) == NULL) {
 		ret = SSH_ERR_ALLOC_FAIL;
 		goto out;
 	}
-	if (!ECDSA_SIG_set0(sig, sig_r, sig_s)) {
+	if (!ECDSA_SIG_set0(esig, sig_r, sig_s)) {
 		ret = SSH_ERR_LIBCRYPTO_ERROR;
 		goto out;
 	}
@@ -288,11 +288,11 @@ ssh_ecdsa_sk_verify(const struct sshkey *key,
 		goto out;
 	}
 	if (is_webauthn) {
-		if ((ret = webauthn_check_prepare_hash(data, datalen,
+		if ((ret = webauthn_check_prepare_hash(data, dlen,
 		    webauthn_origin, webauthn_wrapper, sig_flags, webauthn_exts,
 		    msghash, sizeof(msghash))) != 0)
 			goto out;
-	} else if ((ret = ssh_digest_memory(SSH_DIGEST_SHA256, data, datalen,
+	} else if ((ret = ssh_digest_memory(SSH_DIGEST_SHA256, data, dlen,
 	    msghash, sizeof(msghash))) != 0)
 		goto out;
 	/* Application value is hashed before signature */
@@ -326,7 +326,7 @@ ssh_ecdsa_sk_verify(const struct sshkey *key,
 #endif
 
 	/* Verify it */
-	switch (ECDSA_do_verify(sighash, sizeof(sighash), sig, key->ecdsa)) {
+	switch (ECDSA_do_verify(sighash, sizeof(sighash), esig, key->ecdsa)) {
 	case 1:
 		ret = 0;
 		break;
@@ -355,7 +355,7 @@ ssh_ecdsa_sk_verify(const struct sshkey *key,
 	sshbuf_free(original_signed);
 	sshbuf_free(sigbuf);
 	sshbuf_free(b);
-	ECDSA_SIG_free(sig);
+	ECDSA_SIG_free(esig);
 	BN_clear_free(sig_r);
 	BN_clear_free(sig_s);
 	free(ktype);
@@ -371,6 +371,8 @@ static const struct sshkey_impl_funcs sshkey_ecdsa_sk_funcs = {
 	/* .ssh_deserialize_public = */ ssh_ecdsa_sk_deserialize_public,
 	/* .generate = */	NULL,
 	/* .copy_public = */	ssh_ecdsa_sk_copy_public,
+	/* .sign = */		NULL,
+	/* .verify = */		ssh_ecdsa_sk_verify,
 };
 
 const struct sshkey_impl sshkey_ecdsa_sk_impl = {

--- a/ssh-ecdsa-sk.c
+++ b/ssh-ecdsa-sk.c
@@ -43,14 +43,24 @@
 #define SSHKEY_INTERNAL
 #include "sshkey.h"
 
+/* Reuse some ECDSA internals */
+extern struct sshkey_impl_funcs sshkey_ecdsa_funcs;
+
 static void
 ssh_ecdsa_sk_cleanup(struct sshkey *k)
 {
-	free(k->sk_application);
-	sshbuf_free(k->sk_key_handle);
-	sshbuf_free(k->sk_reserved);
-	EC_KEY_free(k->ecdsa);
-	k->ecdsa = NULL;
+	sshkey_sk_cleanup(k);
+	sshkey_ecdsa_funcs.cleanup(k);
+}
+
+static int
+ssh_ecdsa_sk_equal(const struct sshkey *a, const struct sshkey *b)
+{
+	if (!sshkey_sk_fields_equal(a, b))
+		return 0;
+	if (!sshkey_ecdsa_funcs.equal(a, b))
+		return 0;
+	return 1;
 }
 
 /*
@@ -317,6 +327,7 @@ static const struct sshkey_impl_funcs sshkey_ecdsa_sk_funcs = {
 	/* .size = */		NULL,
 	/* .alloc = */		NULL,
 	/* .cleanup = */	ssh_ecdsa_sk_cleanup,
+	/* .equal = */		ssh_ecdsa_sk_equal,
 };
 
 const struct sshkey_impl sshkey_ecdsa_sk_impl = {

--- a/ssh-ecdsa.c
+++ b/ssh-ecdsa.c
@@ -180,15 +180,17 @@ ssh_ecdsa_deserialize_public(const char *ktype, struct sshbuf *b,
 }
 
 /* ARGSUSED */
-int
-ssh_ecdsa_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
-    const u_char *data, size_t datalen, u_int compat)
+static int
+ssh_ecdsa_sign(struct sshkey *key,
+    u_char **sigp, size_t *lenp,
+    const u_char *data, size_t dlen,
+    const char *alg, const char *sk_provider, const char *sk_pin, u_int compat)
 {
-	ECDSA_SIG *sig = NULL;
+	ECDSA_SIG *esig = NULL;
 	const BIGNUM *sig_r, *sig_s;
 	int hash_alg;
 	u_char digest[SSH_DIGEST_MAX_LENGTH];
-	size_t len, dlen;
+	size_t len, hlen;
 	struct sshbuf *b = NULL, *bb = NULL;
 	int ret = SSH_ERR_INTERNAL_ERROR;
 
@@ -202,13 +204,13 @@ ssh_ecdsa_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
 		return SSH_ERR_INVALID_ARGUMENT;
 
 	if ((hash_alg = sshkey_ec_nid_to_hash_alg(key->ecdsa_nid)) == -1 ||
-	    (dlen = ssh_digest_bytes(hash_alg)) == 0)
+	    (hlen = ssh_digest_bytes(hash_alg)) == 0)
 		return SSH_ERR_INTERNAL_ERROR;
-	if ((ret = ssh_digest_memory(hash_alg, data, datalen,
+	if ((ret = ssh_digest_memory(hash_alg, data, dlen,
 	    digest, sizeof(digest))) != 0)
 		goto out;
 
-	if ((sig = ECDSA_do_sign(digest, dlen, key->ecdsa)) == NULL) {
+	if ((esig = ECDSA_do_sign(digest, hlen, key->ecdsa)) == NULL) {
 		ret = SSH_ERR_LIBCRYPTO_ERROR;
 		goto out;
 	}
@@ -217,7 +219,7 @@ ssh_ecdsa_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
 		ret = SSH_ERR_ALLOC_FAIL;
 		goto out;
 	}
-	ECDSA_SIG_get0(sig, &sig_r, &sig_s);
+	ECDSA_SIG_get0(esig, &sig_r, &sig_s);
 	if ((ret = sshbuf_put_bignum2(bb, sig_r)) != 0 ||
 	    (ret = sshbuf_put_bignum2(bb, sig_s)) != 0)
 		goto out;
@@ -239,36 +241,37 @@ ssh_ecdsa_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
 	explicit_bzero(digest, sizeof(digest));
 	sshbuf_free(b);
 	sshbuf_free(bb);
-	ECDSA_SIG_free(sig);
+	ECDSA_SIG_free(esig);
 	return ret;
 }
 
 /* ARGSUSED */
-int
+static int
 ssh_ecdsa_verify(const struct sshkey *key,
-    const u_char *signature, size_t signaturelen,
-    const u_char *data, size_t datalen, u_int compat)
+    const u_char *sig, size_t siglen,
+    const u_char *data, size_t dlen, const char *alg, u_int compat,
+    struct sshkey_sig_details **detailsp)
 {
-	ECDSA_SIG *sig = NULL;
+	ECDSA_SIG *esig = NULL;
 	BIGNUM *sig_r = NULL, *sig_s = NULL;
 	int hash_alg;
 	u_char digest[SSH_DIGEST_MAX_LENGTH];
-	size_t dlen;
+	size_t hlen;
 	int ret = SSH_ERR_INTERNAL_ERROR;
 	struct sshbuf *b = NULL, *sigbuf = NULL;
 	char *ktype = NULL;
 
 	if (key == NULL || key->ecdsa == NULL ||
 	    sshkey_type_plain(key->type) != KEY_ECDSA ||
-	    signature == NULL || signaturelen == 0)
+	    sig == NULL || siglen == 0)
 		return SSH_ERR_INVALID_ARGUMENT;
 
 	if ((hash_alg = sshkey_ec_nid_to_hash_alg(key->ecdsa_nid)) == -1 ||
-	    (dlen = ssh_digest_bytes(hash_alg)) == 0)
+	    (hlen = ssh_digest_bytes(hash_alg)) == 0)
 		return SSH_ERR_INTERNAL_ERROR;
 
 	/* fetch signature */
-	if ((b = sshbuf_from(signature, signaturelen)) == NULL)
+	if ((b = sshbuf_from(sig, siglen)) == NULL)
 		return SSH_ERR_ALLOC_FAIL;
 	if (sshbuf_get_cstring(b, &ktype, NULL) != 0 ||
 	    sshbuf_froms(b, &sigbuf) != 0) {
@@ -290,11 +293,11 @@ ssh_ecdsa_verify(const struct sshkey *key,
 		ret = SSH_ERR_INVALID_FORMAT;
 		goto out;
 	}
-	if ((sig = ECDSA_SIG_new()) == NULL) {
+	if ((esig = ECDSA_SIG_new()) == NULL) {
 		ret = SSH_ERR_ALLOC_FAIL;
 		goto out;
 	}
-	if (!ECDSA_SIG_set0(sig, sig_r, sig_s)) {
+	if (!ECDSA_SIG_set0(esig, sig_r, sig_s)) {
 		ret = SSH_ERR_LIBCRYPTO_ERROR;
 		goto out;
 	}
@@ -304,11 +307,11 @@ ssh_ecdsa_verify(const struct sshkey *key,
 		ret = SSH_ERR_UNEXPECTED_TRAILING_DATA;
 		goto out;
 	}
-	if ((ret = ssh_digest_memory(hash_alg, data, datalen,
+	if ((ret = ssh_digest_memory(hash_alg, data, dlen,
 	    digest, sizeof(digest))) != 0)
 		goto out;
 
-	switch (ECDSA_do_verify(digest, dlen, sig, key->ecdsa)) {
+	switch (ECDSA_do_verify(digest, hlen, esig, key->ecdsa)) {
 	case 1:
 		ret = 0;
 		break;
@@ -324,7 +327,7 @@ ssh_ecdsa_verify(const struct sshkey *key,
 	explicit_bzero(digest, sizeof(digest));
 	sshbuf_free(sigbuf);
 	sshbuf_free(b);
-	ECDSA_SIG_free(sig);
+	ECDSA_SIG_free(esig);
 	BN_clear_free(sig_r);
 	BN_clear_free(sig_s);
 	free(ktype);
@@ -341,6 +344,8 @@ const struct sshkey_impl_funcs sshkey_ecdsa_funcs = {
 	/* .ssh_deserialize_public = */ ssh_ecdsa_deserialize_public,
 	/* .generate = */	ssh_ecdsa_generate,
 	/* .copy_public = */	ssh_ecdsa_copy_public,
+	/* .sign = */		ssh_ecdsa_sign,
+	/* .verify = */		ssh_ecdsa_verify,
 };
 
 const struct sshkey_impl sshkey_ecdsa_nistp256_impl = {

--- a/ssh-ecdsa.c
+++ b/ssh-ecdsa.c
@@ -149,50 +149,69 @@ static int
 ssh_ecdsa_deserialize_public(const char *ktype, struct sshbuf *b,
     struct sshkey *key)
 {
-	int ret = SSH_ERR_INTERNAL_ERROR;
+	int r;
 	char *curve = NULL;
-	EC_POINT *q = NULL;
 
-	key->ecdsa_nid = sshkey_ecdsa_nid_from_name(ktype);
-	if (sshbuf_get_cstring(b, &curve, NULL) != 0) {
-		ret = SSH_ERR_INVALID_FORMAT;
+	if ((key->ecdsa_nid = sshkey_ecdsa_nid_from_name(ktype)) == -1)
+		return SSH_ERR_INVALID_ARGUMENT;
+	if ((r = sshbuf_get_cstring(b, &curve, NULL)) != 0)
 		goto out;
-	}
 	if (key->ecdsa_nid != sshkey_curve_name_to_nid(curve)) {
-		ret = SSH_ERR_EC_CURVE_MISMATCH;
+		r = SSH_ERR_EC_CURVE_MISMATCH;
 		goto out;
 	}
 	EC_KEY_free(key->ecdsa);
+	key->ecdsa = NULL;
 	if ((key->ecdsa = EC_KEY_new_by_curve_name(key->ecdsa_nid)) == NULL) {
-		ret = SSH_ERR_EC_CURVE_INVALID;
+		r = SSH_ERR_LIBCRYPTO_ERROR;
 		goto out;
 	}
-	if ((q = EC_POINT_new(EC_KEY_get0_group(key->ecdsa))) == NULL) {
-		ret = SSH_ERR_ALLOC_FAIL;
+	if ((r = sshbuf_get_eckey(b, key->ecdsa)) != 0)
+		goto out;
+	if (sshkey_ec_validate_public(EC_KEY_get0_group(key->ecdsa),
+	    EC_KEY_get0_public_key(key->ecdsa)) != 0) {
+		r = SSH_ERR_KEY_INVALID_EC_VALUE;
 		goto out;
 	}
-	if (sshbuf_get_ec(b, q, EC_KEY_get0_group(key->ecdsa)) != 0) {
-		ret = SSH_ERR_INVALID_FORMAT;
-		goto out;
-	}
-	if (sshkey_ec_validate_public(EC_KEY_get0_group(key->ecdsa), q) != 0) {
-		ret = SSH_ERR_KEY_INVALID_EC_VALUE;
-		goto out;
-	}
-	if (EC_KEY_set_public_key(key->ecdsa, q) != 1) {
-		/* XXX assume it is a allocation error */
-		ret = SSH_ERR_ALLOC_FAIL;
-		goto out;
-	}
-#ifdef DEBUG_PK
-	sshkey_dump_ec_point(EC_KEY_get0_group(key->ecdsa), q);
-#endif
 	/* success */
-	ret = 0;
+	r = 0;
+#ifdef DEBUG_PK
+	sshkey_dump_ec_point(EC_KEY_get0_group(key->ecdsa),
+	    EC_KEY_get0_public_key(key->ecdsa));
+#endif
  out:
 	free(curve);
-	EC_POINT_free(q);
-	return ret;
+	if (r != 0) {
+		EC_KEY_free(key->ecdsa);
+		key->ecdsa = NULL;
+	}
+	return r;
+}
+
+static int
+ssh_ecdsa_deserialize_private(const char *ktype, struct sshbuf *b,
+    struct sshkey *key)
+{
+	int r;
+	BIGNUM *exponent = NULL;
+
+	if (!sshkey_is_cert(key)) {
+		if ((r = ssh_ecdsa_deserialize_public(ktype, b, key)) != 0)
+			return r;
+	}
+	if ((r = sshbuf_get_bignum2(b, &exponent)) != 0)
+		goto out;
+	if (EC_KEY_set_private_key(key->ecdsa, exponent) != 1) {
+		r = SSH_ERR_LIBCRYPTO_ERROR;
+		goto out;
+	}
+	if ((r = sshkey_ec_validate_private(key->ecdsa)) != 0)
+		goto out;
+	/* success */
+	r = 0;
+ out:
+	BN_clear_free(exponent);
+	return r;
 }
 
 /* ARGSUSED */
@@ -359,6 +378,7 @@ const struct sshkey_impl_funcs sshkey_ecdsa_funcs = {
 	/* .ssh_serialize_public = */ ssh_ecdsa_serialize_public,
 	/* .ssh_deserialize_public = */ ssh_ecdsa_deserialize_public,
 	/* .ssh_serialize_private = */ ssh_ecdsa_serialize_private,
+	/* .ssh_deserialize_private = */ ssh_ecdsa_deserialize_private,
 	/* .generate = */	ssh_ecdsa_generate,
 	/* .copy_public = */	ssh_ecdsa_copy_public,
 	/* .sign = */		ssh_ecdsa_sign,

--- a/ssh-ecdsa.c
+++ b/ssh-ecdsa.c
@@ -100,6 +100,22 @@ ssh_ecdsa_serialize_public(const struct sshkey *key, struct sshbuf *b,
 }
 
 static int
+ssh_ecdsa_serialize_private(const struct sshkey *key, struct sshbuf *b,
+    enum sshkey_serialize_rep opts)
+{
+	int r;
+
+	if (!sshkey_is_cert(key)) {
+		if ((r = ssh_ecdsa_serialize_public(key, b, opts)) != 0)
+			return r;
+	}
+	if ((r = sshbuf_put_bignum2(b,
+	    EC_KEY_get0_private_key(key->ecdsa))) != 0)
+		return r;
+	return 0;
+}
+
+static int
 ssh_ecdsa_generate(struct sshkey *k, int bits)
 {
 	EC_KEY *private;
@@ -342,6 +358,7 @@ const struct sshkey_impl_funcs sshkey_ecdsa_funcs = {
 	/* .equal = */		ssh_ecdsa_equal,
 	/* .ssh_serialize_public = */ ssh_ecdsa_serialize_public,
 	/* .ssh_deserialize_public = */ ssh_ecdsa_deserialize_public,
+	/* .ssh_serialize_private = */ ssh_ecdsa_serialize_private,
 	/* .generate = */	ssh_ecdsa_generate,
 	/* .copy_public = */	ssh_ecdsa_copy_public,
 	/* .sign = */		ssh_ecdsa_sign,

--- a/ssh-ecdsa.c
+++ b/ssh-ecdsa.c
@@ -79,7 +79,25 @@ ssh_ecdsa_equal(const struct sshkey *a, const struct sshkey *b)
 		return 0;
 	if (EC_POINT_cmp(grp_a, pub_a, pub_b, NULL) != 0)
 		return 0;
+
 	return 1;
+}
+
+static int
+ssh_ecdsa_serialize_public(const struct sshkey *key, struct sshbuf *b,
+    const char *typename, enum sshkey_serialize_rep opts)
+{
+	int r;
+
+	if (key->ecdsa == NULL)
+		return SSH_ERR_INVALID_ARGUMENT;
+	if ((r = sshbuf_put_cstring(b, typename)) != 0 ||
+	    (r = sshbuf_put_cstring(b,
+	    sshkey_curve_nid_to_name(key->ecdsa_nid))) != 0 ||
+	    (r = sshbuf_put_eckey(b, key->ecdsa)) != 0)
+		return r;
+
+	return 0;
 }
 
 /* ARGSUSED */
@@ -240,6 +258,7 @@ const struct sshkey_impl_funcs sshkey_ecdsa_funcs = {
 	/* .alloc = */		NULL,
 	/* .cleanup = */	ssh_ecdsa_cleanup,
 	/* .equal = */		ssh_ecdsa_equal,
+	/* .ssh_serialize_public = */ ssh_ecdsa_serialize_public,
 };
 
 const struct sshkey_impl sshkey_ecdsa_nistp256_impl = {

--- a/ssh-ecdsa.c
+++ b/ssh-ecdsa.c
@@ -39,6 +39,28 @@
 #define SSHKEY_INTERNAL
 #include "sshkey.h"
 
+static u_int
+ssh_ecdsa_size(const struct sshkey *key)
+{
+	switch (key->ecdsa_nid) {
+	case NID_X9_62_prime256v1:
+		return 256;
+	case NID_secp384r1:
+		return 384;
+	case NID_secp521r1:
+		return 521;
+	default:
+		return 0;
+	}
+}
+
+static void
+ssh_ecdsa_cleanup(struct sshkey *k)
+{
+	EC_KEY_free(k->ecdsa);
+	k->ecdsa = NULL;
+}
+
 /* ARGSUSED */
 int
 ssh_ecdsa_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
@@ -190,3 +212,81 @@ ssh_ecdsa_verify(const struct sshkey *key,
 	free(ktype);
 	return ret;
 }
+
+static const struct sshkey_impl_funcs sshkey_ecdsa_funcs = {
+	/* .size = */		ssh_ecdsa_size,
+	/* .alloc = */		NULL,
+	/* .cleanup = */	ssh_ecdsa_cleanup,
+};
+
+const struct sshkey_impl sshkey_ecdsa_nistp256_impl = {
+	/* .name = */		"ecdsa-sha2-nistp256",
+	/* .shortname = */	"ECDSA",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_ECDSA,
+	/* .nid = */		NID_X9_62_prime256v1,
+	/* .cert = */		0,
+	/* .sigonly = */	0,
+	/* .keybits = */	0,
+	/* .funcs = */		&sshkey_ecdsa_funcs,
+};
+
+const struct sshkey_impl sshkey_ecdsa_nistp256_cert_impl = {
+	/* .name = */		"ecdsa-sha2-nistp256-cert-v01@openssh.com",
+	/* .shortname = */	"ECDSA-CERT",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_ECDSA_CERT,
+	/* .nid = */		NID_X9_62_prime256v1,
+	/* .cert = */		1,
+	/* .sigonly = */	0,
+	/* .keybits = */	0,
+	/* .funcs = */		&sshkey_ecdsa_funcs,
+};
+
+const struct sshkey_impl sshkey_ecdsa_nistp384_impl = {
+	/* .name = */		"ecdsa-sha2-nistp384",
+	/* .shortname = */	"ECDSA",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_ECDSA,
+	/* .nid = */		NID_secp384r1,
+	/* .cert = */		0,
+	/* .sigonly = */	0,
+	/* .keybits = */	0,
+	/* .funcs = */		&sshkey_ecdsa_funcs,
+};
+
+const struct sshkey_impl sshkey_ecdsa_nistp384_cert_impl = {
+	/* .name = */		"ecdsa-sha2-nistp384-cert-v01@openssh.com",
+	/* .shortname = */	"ECDSA-CERT",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_ECDSA_CERT,
+	/* .nid = */		NID_secp384r1,
+	/* .cert = */		1,
+	/* .sigonly = */	0,
+	/* .keybits = */	0,
+	/* .funcs = */		&sshkey_ecdsa_funcs,
+};
+
+const struct sshkey_impl sshkey_ecdsa_nistp521_impl = {
+	/* .name = */		"ecdsa-sha2-nistp521",
+	/* .shortname = */	"ECDSA",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_ECDSA,
+	/* .nid = */		NID_secp521r1,
+	/* .cert = */		0,
+	/* .sigonly = */	0,
+	/* .keybits = */	0,
+	/* .funcs = */		&sshkey_ecdsa_funcs,
+};
+
+const struct sshkey_impl sshkey_ecdsa_nistp521_cert_impl = {
+	/* .name = */		"ecdsa-sha2-nistp521-cert-v01@openssh.com",
+	/* .shortname = */	"ECDSA-CERT",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_ECDSA_CERT,
+	/* .nid = */		NID_secp521r1,
+	/* .cert = */		1,
+	/* .sigonly = */	0,
+	/* .keybits = */	0,
+	/* .funcs = */		&sshkey_ecdsa_funcs,
+};

--- a/ssh-ecdsa.c
+++ b/ssh-ecdsa.c
@@ -118,6 +118,18 @@ ssh_ecdsa_generate(struct sshkey *k, int bits)
 	return 0;
 }
 
+static int
+ssh_ecdsa_copy_public(const struct sshkey *from, struct sshkey *to)
+{
+	to->ecdsa_nid = from->ecdsa_nid;
+	if ((to->ecdsa = EC_KEY_new_by_curve_name(from->ecdsa_nid)) == NULL)
+		return SSH_ERR_ALLOC_FAIL;
+	if (EC_KEY_set_public_key(to->ecdsa,
+	    EC_KEY_get0_public_key(from->ecdsa)) != 1)
+		return SSH_ERR_LIBCRYPTO_ERROR; /* caller will free k->ecdsa */
+	return 0;
+}
+
 /* ARGSUSED */
 int
 ssh_ecdsa_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
@@ -278,6 +290,7 @@ const struct sshkey_impl_funcs sshkey_ecdsa_funcs = {
 	/* .equal = */		ssh_ecdsa_equal,
 	/* .ssh_serialize_public = */ ssh_ecdsa_serialize_public,
 	/* .generate = */	ssh_ecdsa_generate,
+	/* .copy_public = */	ssh_ecdsa_copy_public,
 };
 
 const struct sshkey_impl sshkey_ecdsa_nistp256_impl = {

--- a/ssh-ecdsa.c
+++ b/ssh-ecdsa.c
@@ -85,14 +85,13 @@ ssh_ecdsa_equal(const struct sshkey *a, const struct sshkey *b)
 
 static int
 ssh_ecdsa_serialize_public(const struct sshkey *key, struct sshbuf *b,
-    const char *typename, enum sshkey_serialize_rep opts)
+    enum sshkey_serialize_rep opts)
 {
 	int r;
 
 	if (key->ecdsa == NULL)
 		return SSH_ERR_INVALID_ARGUMENT;
-	if ((r = sshbuf_put_cstring(b, typename)) != 0 ||
-	    (r = sshbuf_put_cstring(b,
+	if ((r = sshbuf_put_cstring(b,
 	    sshkey_curve_nid_to_name(key->ecdsa_nid))) != 0 ||
 	    (r = sshbuf_put_eckey(b, key->ecdsa)) != 0)
 		return r;
@@ -128,6 +127,56 @@ ssh_ecdsa_copy_public(const struct sshkey *from, struct sshkey *to)
 	    EC_KEY_get0_public_key(from->ecdsa)) != 1)
 		return SSH_ERR_LIBCRYPTO_ERROR; /* caller will free k->ecdsa */
 	return 0;
+}
+
+static int
+ssh_ecdsa_deserialize_public(const char *ktype, struct sshbuf *b,
+    struct sshkey *key)
+{
+	int ret = SSH_ERR_INTERNAL_ERROR;
+	char *curve = NULL;
+	EC_POINT *q = NULL;
+
+	key->ecdsa_nid = sshkey_ecdsa_nid_from_name(ktype);
+	if (sshbuf_get_cstring(b, &curve, NULL) != 0) {
+		ret = SSH_ERR_INVALID_FORMAT;
+		goto out;
+	}
+	if (key->ecdsa_nid != sshkey_curve_name_to_nid(curve)) {
+		ret = SSH_ERR_EC_CURVE_MISMATCH;
+		goto out;
+	}
+	EC_KEY_free(key->ecdsa);
+	if ((key->ecdsa = EC_KEY_new_by_curve_name(key->ecdsa_nid)) == NULL) {
+		ret = SSH_ERR_EC_CURVE_INVALID;
+		goto out;
+	}
+	if ((q = EC_POINT_new(EC_KEY_get0_group(key->ecdsa))) == NULL) {
+		ret = SSH_ERR_ALLOC_FAIL;
+		goto out;
+	}
+	if (sshbuf_get_ec(b, q, EC_KEY_get0_group(key->ecdsa)) != 0) {
+		ret = SSH_ERR_INVALID_FORMAT;
+		goto out;
+	}
+	if (sshkey_ec_validate_public(EC_KEY_get0_group(key->ecdsa), q) != 0) {
+		ret = SSH_ERR_KEY_INVALID_EC_VALUE;
+		goto out;
+	}
+	if (EC_KEY_set_public_key(key->ecdsa, q) != 1) {
+		/* XXX assume it is a allocation error */
+		ret = SSH_ERR_ALLOC_FAIL;
+		goto out;
+	}
+#ifdef DEBUG_PK
+	sshkey_dump_ec_point(EC_KEY_get0_group(key->ecdsa), q);
+#endif
+	/* success */
+	ret = 0;
+ out:
+	free(curve);
+	EC_POINT_free(q);
+	return ret;
 }
 
 /* ARGSUSED */
@@ -289,6 +338,7 @@ const struct sshkey_impl_funcs sshkey_ecdsa_funcs = {
 	/* .cleanup = */	ssh_ecdsa_cleanup,
 	/* .equal = */		ssh_ecdsa_equal,
 	/* .ssh_serialize_public = */ ssh_ecdsa_serialize_public,
+	/* .ssh_deserialize_public = */ ssh_ecdsa_deserialize_public,
 	/* .generate = */	ssh_ecdsa_generate,
 	/* .copy_public = */	ssh_ecdsa_copy_public,
 };

--- a/ssh-ed25519-sk.c
+++ b/ssh-ed25519-sk.c
@@ -92,10 +92,10 @@ ssh_ed25519_sk_deserialize_public(const char *ktype, struct sshbuf *b,
 	return 0;
 }
 
-int
+static int
 ssh_ed25519_sk_verify(const struct sshkey *key,
-    const u_char *signature, size_t signaturelen,
-    const u_char *data, size_t datalen, u_int compat,
+    const u_char *sig, size_t siglen,
+    const u_char *data, size_t dlen, const char *alg, u_int compat,
     struct sshkey_sig_details **detailsp)
 {
 	struct sshbuf *b = NULL;
@@ -120,10 +120,10 @@ ssh_ed25519_sk_verify(const struct sshkey *key,
 	if (key == NULL ||
 	    sshkey_type_plain(key->type) != KEY_ED25519_SK ||
 	    key->ed25519_pk == NULL ||
-	    signature == NULL || signaturelen == 0)
+	    sig == NULL || siglen == 0)
 		return SSH_ERR_INVALID_ARGUMENT;
 
-	if ((b = sshbuf_from(signature, signaturelen)) == NULL)
+	if ((b = sshbuf_from(sig, siglen)) == NULL)
 		return SSH_ERR_ALLOC_FAIL;
 	if (sshbuf_get_cstring(b, &ktype, NULL) != 0 ||
 	    sshbuf_get_string_direct(b, &sigblob, &len) != 0 ||
@@ -154,7 +154,7 @@ ssh_ed25519_sk_verify(const struct sshkey *key,
 	}
 	if (ssh_digest_memory(SSH_DIGEST_SHA256, key->sk_application,
 	    strlen(key->sk_application), apphash, sizeof(apphash)) != 0 ||
-	    ssh_digest_memory(SSH_DIGEST_SHA256, data, datalen,
+	    ssh_digest_memory(SSH_DIGEST_SHA256, data, dlen,
 	    msghash, sizeof(msghash)) != 0) {
 		r = SSH_ERR_INVALID_ARGUMENT;
 		goto out;
@@ -228,6 +228,8 @@ static const struct sshkey_impl_funcs sshkey_ed25519_sk_funcs = {
 	/* .ssh_deserialize_public = */ ssh_ed25519_sk_deserialize_public,
 	/* .generate = */	NULL,
 	/* .copy_public = */	ssh_ed25519_sk_copy_public,
+	/* .sign = */		NULL,
+	/* .verify = */		ssh_ed25519_sk_verify,
 };
 
 const struct sshkey_impl sshkey_ed25519_sk_impl = {

--- a/ssh-ed25519-sk.c
+++ b/ssh-ed25519-sk.c
@@ -33,6 +33,18 @@
 #include "ssh.h"
 #include "digest.h"
 
+static void
+ssh_ed25519_sk_cleanup(struct sshkey *k)
+{
+	free(k->sk_application);
+	sshbuf_free(k->sk_key_handle);
+	sshbuf_free(k->sk_reserved);
+	freezero(k->ed25519_pk, ED25519_PK_SZ);
+	freezero(k->ed25519_sk, ED25519_SK_SZ);
+	k->ed25519_pk = NULL;
+	k->ed25519_sk = NULL;
+}
+
 int
 ssh_ed25519_sk_verify(const struct sshkey *key,
     const u_char *signature, size_t signaturelen,
@@ -159,3 +171,33 @@ ssh_ed25519_sk_verify(const struct sshkey *key,
 	free(ktype);
 	return r;
 }
+
+static const struct sshkey_impl_funcs sshkey_ed25519_sk_funcs = {
+	/* .size = */		NULL,
+	/* .alloc = */		NULL,
+	/* .cleanup = */	ssh_ed25519_sk_cleanup,
+};
+
+const struct sshkey_impl sshkey_ed25519_sk_impl = {
+	/* .name = */		"sk-ssh-ed25519@openssh.com",
+	/* .shortname = */	"ED25519-SK",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_ED25519_SK,
+	/* .nid = */		0,
+	/* .cert = */		0,
+	/* .sigonly = */	0,
+	/* .keybits = */	256,
+	/* .funcs = */		&sshkey_ed25519_sk_funcs,
+};
+
+const struct sshkey_impl sshkey_ed25519_sk_cert_impl = {
+	/* .name = */		"sk-ssh-ed25519-cert-v01@openssh.com",
+	/* .shortname = */	"ED25519-SK-CERT",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_ED25519_SK_CERT,
+	/* .nid = */		0,
+	/* .cert = */		1,
+	/* .sigonly = */	0,
+	/* .keybits = */	256,
+	/* .funcs = */		&sshkey_ed25519_sk_funcs,
+};

--- a/ssh-ed25519-sk.c
+++ b/ssh-ed25519-sk.c
@@ -68,6 +68,20 @@ ssh_ed25519_sk_serialize_public(const struct sshkey *key, struct sshbuf *b,
 }
 
 static int
+ssh_ed25519_sk_serialize_private(const struct sshkey *key, struct sshbuf *b,
+    enum sshkey_serialize_rep opts)
+{
+	int r;
+
+	if ((r = sshkey_ed25519_funcs.serialize_public(key, b, opts)) != 0)
+		return r;
+	if ((r = sshkey_serialize_private_sk(key, b)) != 0)
+		return r;
+
+	return 0;
+}
+
+static int
 ssh_ed25519_sk_copy_public(const struct sshkey *from, struct sshkey *to)
 {
 	int r;
@@ -226,6 +240,7 @@ static const struct sshkey_impl_funcs sshkey_ed25519_sk_funcs = {
 	/* .equal = */		ssh_ed25519_sk_equal,
 	/* .ssh_serialize_public = */ ssh_ed25519_sk_serialize_public,
 	/* .ssh_deserialize_public = */ ssh_ed25519_sk_deserialize_public,
+	/* .ssh_serialize_private = */ ssh_ed25519_sk_serialize_private,
 	/* .generate = */	NULL,
 	/* .copy_public = */	ssh_ed25519_sk_copy_public,
 	/* .sign = */		NULL,

--- a/ssh-ed25519-sk.c
+++ b/ssh-ed25519-sk.c
@@ -107,6 +107,19 @@ ssh_ed25519_sk_deserialize_public(const char *ktype, struct sshbuf *b,
 }
 
 static int
+ssh_ed25519_sk_deserialize_private(const char *ktype, struct sshbuf *b,
+    struct sshkey *key)
+{
+	int r;
+
+	if ((r = sshkey_ed25519_funcs.deserialize_public(ktype, b, key)) != 0)
+		return r;
+	if ((r = sshkey_private_deserialize_sk(b, key)) != 0)
+		return r;
+	return 0;
+}
+
+static int
 ssh_ed25519_sk_verify(const struct sshkey *key,
     const u_char *sig, size_t siglen,
     const u_char *data, size_t dlen, const char *alg, u_int compat,
@@ -241,6 +254,7 @@ static const struct sshkey_impl_funcs sshkey_ed25519_sk_funcs = {
 	/* .ssh_serialize_public = */ ssh_ed25519_sk_serialize_public,
 	/* .ssh_deserialize_public = */ ssh_ed25519_sk_deserialize_public,
 	/* .ssh_serialize_private = */ ssh_ed25519_sk_serialize_private,
+	/* .ssh_deserialize_private = */ ssh_ed25519_sk_deserialize_private,
 	/* .generate = */	NULL,
 	/* .copy_public = */	ssh_ed25519_sk_copy_public,
 	/* .sign = */		NULL,

--- a/ssh-ed25519-sk.c
+++ b/ssh-ed25519-sk.c
@@ -68,6 +68,18 @@ ssh_ed25519_sk_serialize_public(const struct sshkey *key, struct sshbuf *b,
 	return 0;
 }
 
+static int
+ssh_ed25519_sk_copy_public(const struct sshkey *from, struct sshkey *to)
+{
+	int r;
+
+	if ((r = sshkey_ed25519_funcs.copy_public(from, to)) != 0)
+		return r;
+	if ((r = sshkey_copy_public_sk(from, to)) != 0)
+		return r;
+	return 0;
+}
+
 int
 ssh_ed25519_sk_verify(const struct sshkey *key,
     const u_char *signature, size_t signaturelen,
@@ -202,6 +214,7 @@ static const struct sshkey_impl_funcs sshkey_ed25519_sk_funcs = {
 	/* .equal = */		ssh_ed25519_sk_equal,
 	/* .ssh_serialize_public = */ ssh_ed25519_sk_serialize_public,
 	/* .generate = */	NULL,
+	/* .copy_public = */	ssh_ed25519_sk_copy_public,
 };
 
 const struct sshkey_impl sshkey_ed25519_sk_impl = {

--- a/ssh-ed25519-sk.c
+++ b/ssh-ed25519-sk.c
@@ -201,6 +201,7 @@ static const struct sshkey_impl_funcs sshkey_ed25519_sk_funcs = {
 	/* .cleanup = */	ssh_ed25519_sk_cleanup,
 	/* .equal = */		ssh_ed25519_sk_equal,
 	/* .ssh_serialize_public = */ ssh_ed25519_sk_serialize_public,
+	/* .generate = */	NULL,
 };
 
 const struct sshkey_impl sshkey_ed25519_sk_impl = {

--- a/ssh-ed25519-sk.c
+++ b/ssh-ed25519-sk.c
@@ -33,16 +33,24 @@
 #include "ssh.h"
 #include "digest.h"
 
+/* Reuse some ED25519 internals */
+extern struct sshkey_impl_funcs sshkey_ed25519_funcs;
+
 static void
 ssh_ed25519_sk_cleanup(struct sshkey *k)
 {
-	free(k->sk_application);
-	sshbuf_free(k->sk_key_handle);
-	sshbuf_free(k->sk_reserved);
-	freezero(k->ed25519_pk, ED25519_PK_SZ);
-	freezero(k->ed25519_sk, ED25519_SK_SZ);
-	k->ed25519_pk = NULL;
-	k->ed25519_sk = NULL;
+	sshkey_sk_cleanup(k);
+	sshkey_ed25519_funcs.cleanup(k);
+}
+
+static int
+ssh_ed25519_sk_equal(const struct sshkey *a, const struct sshkey *b)
+{
+	if (!sshkey_sk_fields_equal(a, b))
+		return 0;
+	if (!sshkey_ed25519_funcs.equal(a, b))
+		return 0;
+	return 1;
 }
 
 int
@@ -176,6 +184,7 @@ static const struct sshkey_impl_funcs sshkey_ed25519_sk_funcs = {
 	/* .size = */		NULL,
 	/* .alloc = */		NULL,
 	/* .cleanup = */	ssh_ed25519_sk_cleanup,
+	/* .equal = */		ssh_ed25519_sk_equal,
 };
 
 const struct sshkey_impl sshkey_ed25519_sk_impl = {

--- a/ssh-ed25519-sk.c
+++ b/ssh-ed25519-sk.c
@@ -55,12 +55,11 @@ ssh_ed25519_sk_equal(const struct sshkey *a, const struct sshkey *b)
 
 static int
 ssh_ed25519_sk_serialize_public(const struct sshkey *key, struct sshbuf *b,
-    const char *typename, enum sshkey_serialize_rep opts)
+    enum sshkey_serialize_rep opts)
 {
 	int r;
 
-	if ((r = sshkey_ed25519_funcs.serialize_public(key, b,
-	    typename, opts)) != 0)
+	if ((r = sshkey_ed25519_funcs.serialize_public(key, b, opts)) != 0)
 		return r;
 	if ((r = sshkey_serialize_sk(key, b)) != 0)
 		return r;
@@ -76,6 +75,19 @@ ssh_ed25519_sk_copy_public(const struct sshkey *from, struct sshkey *to)
 	if ((r = sshkey_ed25519_funcs.copy_public(from, to)) != 0)
 		return r;
 	if ((r = sshkey_copy_public_sk(from, to)) != 0)
+		return r;
+	return 0;
+}
+
+static int
+ssh_ed25519_sk_deserialize_public(const char *ktype, struct sshbuf *b,
+    struct sshkey *key)
+{
+	int r;
+
+	if ((r = sshkey_ed25519_funcs.deserialize_public(ktype, b, key)) != 0)
+		return r;
+	if ((r = sshkey_deserialize_sk(b, key)) != 0)
 		return r;
 	return 0;
 }
@@ -213,6 +225,7 @@ static const struct sshkey_impl_funcs sshkey_ed25519_sk_funcs = {
 	/* .cleanup = */	ssh_ed25519_sk_cleanup,
 	/* .equal = */		ssh_ed25519_sk_equal,
 	/* .ssh_serialize_public = */ ssh_ed25519_sk_serialize_public,
+	/* .ssh_deserialize_public = */ ssh_ed25519_sk_deserialize_public,
 	/* .generate = */	NULL,
 	/* .copy_public = */	ssh_ed25519_sk_copy_public,
 };

--- a/ssh-ed25519-sk.c
+++ b/ssh-ed25519-sk.c
@@ -53,6 +53,21 @@ ssh_ed25519_sk_equal(const struct sshkey *a, const struct sshkey *b)
 	return 1;
 }
 
+static int
+ssh_ed25519_sk_serialize_public(const struct sshkey *key, struct sshbuf *b,
+    const char *typename, enum sshkey_serialize_rep opts)
+{
+	int r;
+
+	if ((r = sshkey_ed25519_funcs.serialize_public(key, b,
+	    typename, opts)) != 0)
+		return r;
+	if ((r = sshkey_serialize_sk(key, b)) != 0)
+		return r;
+
+	return 0;
+}
+
 int
 ssh_ed25519_sk_verify(const struct sshkey *key,
     const u_char *signature, size_t signaturelen,
@@ -185,6 +200,7 @@ static const struct sshkey_impl_funcs sshkey_ed25519_sk_funcs = {
 	/* .alloc = */		NULL,
 	/* .cleanup = */	ssh_ed25519_sk_cleanup,
 	/* .equal = */		ssh_ed25519_sk_equal,
+	/* .ssh_serialize_public = */ ssh_ed25519_sk_serialize_public,
 };
 
 const struct sshkey_impl sshkey_ed25519_sk_impl = {

--- a/ssh-ed25519.c
+++ b/ssh-ed25519.c
@@ -50,14 +50,13 @@ ssh_ed25519_equal(const struct sshkey *a, const struct sshkey *b)
 
 static int
 ssh_ed25519_serialize_public(const struct sshkey *key, struct sshbuf *b,
-    const char *typename, enum sshkey_serialize_rep opts)
+    enum sshkey_serialize_rep opts)
 {
 	int r;
 
 	if (key->ed25519_pk == NULL)
 		return SSH_ERR_INVALID_ARGUMENT;
-	if ((r = sshbuf_put_cstring(b, typename)) != 0 ||
-	    (r = sshbuf_put_string(b, key->ed25519_pk, ED25519_PK_SZ)) != 0)
+	if ((r = sshbuf_put_string(b, key->ed25519_pk, ED25519_PK_SZ)) != 0)
 		return r;
 
 	return 0;
@@ -81,6 +80,24 @@ ssh_ed25519_copy_public(const struct sshkey *from, struct sshkey *to)
 	if ((to->ed25519_pk = malloc(ED25519_PK_SZ)) == NULL)
 		return SSH_ERR_ALLOC_FAIL;
 	memcpy(to->ed25519_pk, from->ed25519_pk, ED25519_PK_SZ);
+	return 0;
+}
+
+static int
+ssh_ed25519_deserialize_public(const char *ktype, struct sshbuf *b,
+    struct sshkey *key)
+{
+	u_char *pk = NULL;
+	size_t len = 0;
+	int r;
+
+	if ((r = sshbuf_get_string(b, &pk, &len)) != 0)
+		return r;
+	if (len != ED25519_PK_SZ) {
+		freezero(pk, len);
+		return SSH_ERR_INVALID_FORMAT;
+	}
+	key->ed25519_pk = pk;
 	return 0;
 }
 
@@ -218,6 +235,7 @@ const struct sshkey_impl_funcs sshkey_ed25519_funcs = {
 	/* .cleanup = */	ssh_ed25519_cleanup,
 	/* .equal = */		ssh_ed25519_equal,
 	/* .ssh_serialize_public = */ ssh_ed25519_serialize_public,
+	/* .ssh_deserialize_public = */ ssh_ed25519_deserialize_public,
 	/* .generate = */	ssh_ed25519_generate,
 	/* .copy_public = */	ssh_ed25519_copy_public,
 };

--- a/ssh-ed25519.c
+++ b/ssh-ed25519.c
@@ -63,6 +63,19 @@ ssh_ed25519_serialize_public(const struct sshkey *key, struct sshbuf *b,
 }
 
 static int
+ssh_ed25519_serialize_private(const struct sshkey *key, struct sshbuf *b,
+    enum sshkey_serialize_rep opts)
+{
+	int r;
+
+	if ((r = sshbuf_put_string(b, key->ed25519_pk, ED25519_PK_SZ)) != 0 ||
+	    (r = sshbuf_put_string(b, key->ed25519_sk, ED25519_SK_SZ)) != 0)
+		return r;
+
+	return 0;
+}
+
+static int
 ssh_ed25519_generate(struct sshkey *k, int bits)
 {
 	if ((k->ed25519_pk = malloc(ED25519_PK_SZ)) == NULL ||
@@ -239,6 +252,7 @@ const struct sshkey_impl_funcs sshkey_ed25519_funcs = {
 	/* .equal = */		ssh_ed25519_equal,
 	/* .ssh_serialize_public = */ ssh_ed25519_serialize_public,
 	/* .ssh_deserialize_public = */ ssh_ed25519_deserialize_public,
+	/* .ssh_serialize_private = */ ssh_ed25519_serialize_private,
 	/* .generate = */	ssh_ed25519_generate,
 	/* .copy_public = */	ssh_ed25519_copy_public,
 	/* .sign = */		ssh_ed25519_sign,

--- a/ssh-ed25519.c
+++ b/ssh-ed25519.c
@@ -48,6 +48,21 @@ ssh_ed25519_equal(const struct sshkey *a, const struct sshkey *b)
 	return 1;
 }
 
+static int
+ssh_ed25519_serialize_public(const struct sshkey *key, struct sshbuf *b,
+    const char *typename, enum sshkey_serialize_rep opts)
+{
+	int r;
+
+	if (key->ed25519_pk == NULL)
+		return SSH_ERR_INVALID_ARGUMENT;
+	if ((r = sshbuf_put_cstring(b, typename)) != 0 ||
+	    (r = sshbuf_put_string(b, key->ed25519_pk, ED25519_PK_SZ)) != 0)
+		return r;
+
+	return 0;
+}
+
 int
 ssh_ed25519_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen, u_int compat)
@@ -181,6 +196,7 @@ const struct sshkey_impl_funcs sshkey_ed25519_funcs = {
 	/* .alloc = */		NULL,
 	/* .cleanup = */	ssh_ed25519_cleanup,
 	/* .equal = */		ssh_ed25519_equal,
+	/* .ssh_serialize_public = */ ssh_ed25519_serialize_public,
 };
 
 const struct sshkey_impl sshkey_ed25519_impl = {

--- a/ssh-ed25519.c
+++ b/ssh-ed25519.c
@@ -29,6 +29,15 @@
 #include "ssherr.h"
 #include "ssh.h"
 
+static void
+ssh_ed25519_cleanup(struct sshkey *k)
+{
+	freezero(k->ed25519_pk, ED25519_PK_SZ);
+	freezero(k->ed25519_sk, ED25519_SK_SZ);
+	k->ed25519_pk = NULL;
+	k->ed25519_sk = NULL;
+}
+
 int
 ssh_ed25519_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen, u_int compat)
@@ -155,3 +164,33 @@ ssh_ed25519_verify(const struct sshkey *key,
 	free(ktype);
 	return r;
 }
+
+static const struct sshkey_impl_funcs sshkey_ed25519_funcs = {
+	/* .size = */		NULL,
+	/* .alloc = */		NULL,
+	/* .cleanup = */	ssh_ed25519_cleanup,
+};
+
+const struct sshkey_impl sshkey_ed25519_impl = {
+	/* .name = */		"ssh-ed25519",
+	/* .shortname = */	"ED25519",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_ED25519,
+	/* .nid = */		0,
+	/* .cert = */		0,
+	/* .sigonly = */	0,
+	/* .keybits = */	256,
+	/* .funcs = */		&sshkey_ed25519_funcs,
+};
+
+const struct sshkey_impl sshkey_ed25519_cert_impl = {
+	/* .name = */		"ssh-ed25519-cert-v01@openssh.com",
+	/* .shortname = */	"ED25519-CERT",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_ED25519_CERT,
+	/* .nid = */		0,
+	/* .cert = */		1,
+	/* .sigonly = */	0,
+	/* .keybits = */	256,
+	/* .funcs = */		&sshkey_ed25519_funcs,
+};

--- a/ssh-ed25519.c
+++ b/ssh-ed25519.c
@@ -73,6 +73,17 @@ ssh_ed25519_generate(struct sshkey *k, int bits)
 	return 0;
 }
 
+static int
+ssh_ed25519_copy_public(const struct sshkey *from, struct sshkey *to)
+{
+	if (from->ed25519_pk == NULL)
+		return 0; /* XXX SSH_ERR_INTERNAL_ERROR ? */
+	if ((to->ed25519_pk = malloc(ED25519_PK_SZ)) == NULL)
+		return SSH_ERR_ALLOC_FAIL;
+	memcpy(to->ed25519_pk, from->ed25519_pk, ED25519_PK_SZ);
+	return 0;
+}
+
 int
 ssh_ed25519_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen, u_int compat)
@@ -208,6 +219,7 @@ const struct sshkey_impl_funcs sshkey_ed25519_funcs = {
 	/* .equal = */		ssh_ed25519_equal,
 	/* .ssh_serialize_public = */ ssh_ed25519_serialize_public,
 	/* .generate = */	ssh_ed25519_generate,
+	/* .copy_public = */	ssh_ed25519_copy_public,
 };
 
 const struct sshkey_impl sshkey_ed25519_impl = {

--- a/ssh-ed25519.c
+++ b/ssh-ed25519.c
@@ -38,6 +38,16 @@ ssh_ed25519_cleanup(struct sshkey *k)
 	k->ed25519_sk = NULL;
 }
 
+static int
+ssh_ed25519_equal(const struct sshkey *a, const struct sshkey *b)
+{
+	if (a->ed25519_pk == NULL || b->ed25519_pk == NULL)
+		return 0;
+	if (memcmp(a->ed25519_pk, b->ed25519_pk, ED25519_PK_SZ) != 0)
+		return 0;
+	return 1;
+}
+
 int
 ssh_ed25519_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen, u_int compat)
@@ -165,10 +175,12 @@ ssh_ed25519_verify(const struct sshkey *key,
 	return r;
 }
 
-static const struct sshkey_impl_funcs sshkey_ed25519_funcs = {
+/* NB. not static; used by ED25519-SK */
+const struct sshkey_impl_funcs sshkey_ed25519_funcs = {
 	/* .size = */		NULL,
 	/* .alloc = */		NULL,
 	/* .cleanup = */	ssh_ed25519_cleanup,
+	/* .equal = */		ssh_ed25519_equal,
 };
 
 const struct sshkey_impl sshkey_ed25519_impl = {

--- a/ssh-ed25519.c
+++ b/ssh-ed25519.c
@@ -101,9 +101,11 @@ ssh_ed25519_deserialize_public(const char *ktype, struct sshbuf *b,
 	return 0;
 }
 
-int
-ssh_ed25519_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
-    const u_char *data, size_t datalen, u_int compat)
+static int
+ssh_ed25519_sign(struct sshkey *key,
+    u_char **sigp, size_t *lenp,
+    const u_char *data, size_t datalen,
+    const char *alg, const char *sk_provider, const char *sk_pin, u_int compat)
 {
 	u_char *sig = NULL;
 	size_t slen = 0, len;
@@ -158,10 +160,11 @@ ssh_ed25519_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
 	return r;
 }
 
-int
+static int
 ssh_ed25519_verify(const struct sshkey *key,
-    const u_char *signature, size_t signaturelen,
-    const u_char *data, size_t datalen, u_int compat)
+    const u_char *sig, size_t siglen,
+    const u_char *data, size_t dlen, const char *alg, u_int compat,
+    struct sshkey_sig_details **detailsp)
 {
 	struct sshbuf *b = NULL;
 	char *ktype = NULL;
@@ -174,11 +177,11 @@ ssh_ed25519_verify(const struct sshkey *key,
 	if (key == NULL ||
 	    sshkey_type_plain(key->type) != KEY_ED25519 ||
 	    key->ed25519_pk == NULL ||
-	    datalen >= INT_MAX - crypto_sign_ed25519_BYTES ||
-	    signature == NULL || signaturelen == 0)
+	    dlen >= INT_MAX - crypto_sign_ed25519_BYTES ||
+	    sig == NULL || siglen == 0)
 		return SSH_ERR_INVALID_ARGUMENT;
 
-	if ((b = sshbuf_from(signature, signaturelen)) == NULL)
+	if ((b = sshbuf_from(sig, siglen)) == NULL)
 		return SSH_ERR_ALLOC_FAIL;
 	if ((r = sshbuf_get_cstring(b, &ktype, NULL)) != 0 ||
 	    (r = sshbuf_get_string_direct(b, &sigblob, &len)) != 0)
@@ -195,23 +198,23 @@ ssh_ed25519_verify(const struct sshkey *key,
 		r = SSH_ERR_INVALID_FORMAT;
 		goto out;
 	}
-	if (datalen >= SIZE_MAX - len) {
+	if (dlen >= SIZE_MAX - len) {
 		r = SSH_ERR_INVALID_ARGUMENT;
 		goto out;
 	}
-	smlen = len + datalen;
+	smlen = len + dlen;
 	mlen = smlen;
 	if ((sm = malloc(smlen)) == NULL || (m = malloc(mlen)) == NULL) {
 		r = SSH_ERR_ALLOC_FAIL;
 		goto out;
 	}
 	memcpy(sm, sigblob, len);
-	memcpy(sm+len, data, datalen);
+	memcpy(sm+len, data, dlen);
 	if ((ret = crypto_sign_ed25519_open(m, &mlen, sm, smlen,
 	    key->ed25519_pk)) != 0) {
 		debug2_f("crypto_sign_ed25519_open failed: %d", ret);
 	}
-	if (ret != 0 || mlen != datalen) {
+	if (ret != 0 || mlen != dlen) {
 		r = SSH_ERR_SIGNATURE_INVALID;
 		goto out;
 	}
@@ -238,6 +241,8 @@ const struct sshkey_impl_funcs sshkey_ed25519_funcs = {
 	/* .ssh_deserialize_public = */ ssh_ed25519_deserialize_public,
 	/* .generate = */	ssh_ed25519_generate,
 	/* .copy_public = */	ssh_ed25519_copy_public,
+	/* .sign = */		ssh_ed25519_sign,
+	/* .verify = */		ssh_ed25519_verify,
 };
 
 const struct sshkey_impl sshkey_ed25519_impl = {

--- a/ssh-ed25519.c
+++ b/ssh-ed25519.c
@@ -115,6 +115,31 @@ ssh_ed25519_deserialize_public(const char *ktype, struct sshbuf *b,
 }
 
 static int
+ssh_ed25519_deserialize_private(const char *ktype, struct sshbuf *b,
+    struct sshkey *key)
+{
+	int r;
+	size_t sklen = 0;
+	u_char *ed25519_sk = NULL;
+
+	if ((r = ssh_ed25519_deserialize_public(NULL, b, key)) != 0)
+		goto out;
+	if ((r = sshbuf_get_string(b, &ed25519_sk, &sklen)) != 0)
+		goto out;
+	if (sklen != ED25519_SK_SZ) {
+		r = SSH_ERR_INVALID_FORMAT;
+		goto out;
+	}
+	key->ed25519_sk = ed25519_sk;
+	ed25519_sk = NULL; /* transferred */
+	/* success */
+	r = 0;
+ out:
+	freezero(ed25519_sk, sklen);
+	return r;
+}
+
+static int
 ssh_ed25519_sign(struct sshkey *key,
     u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen,
@@ -253,6 +278,7 @@ const struct sshkey_impl_funcs sshkey_ed25519_funcs = {
 	/* .ssh_serialize_public = */ ssh_ed25519_serialize_public,
 	/* .ssh_deserialize_public = */ ssh_ed25519_deserialize_public,
 	/* .ssh_serialize_private = */ ssh_ed25519_serialize_private,
+	/* .ssh_deserialize_private = */ ssh_ed25519_deserialize_private,
 	/* .generate = */	ssh_ed25519_generate,
 	/* .copy_public = */	ssh_ed25519_copy_public,
 	/* .sign = */		ssh_ed25519_sign,

--- a/ssh-ed25519.c
+++ b/ssh-ed25519.c
@@ -63,6 +63,16 @@ ssh_ed25519_serialize_public(const struct sshkey *key, struct sshbuf *b,
 	return 0;
 }
 
+static int
+ssh_ed25519_generate(struct sshkey *k, int bits)
+{
+	if ((k->ed25519_pk = malloc(ED25519_PK_SZ)) == NULL ||
+	    (k->ed25519_sk = malloc(ED25519_SK_SZ)) == NULL)
+		return SSH_ERR_ALLOC_FAIL;
+	crypto_sign_ed25519_keypair(k->ed25519_pk, k->ed25519_sk);
+	return 0;
+}
+
 int
 ssh_ed25519_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen, u_int compat)
@@ -197,6 +207,7 @@ const struct sshkey_impl_funcs sshkey_ed25519_funcs = {
 	/* .cleanup = */	ssh_ed25519_cleanup,
 	/* .equal = */		ssh_ed25519_equal,
 	/* .ssh_serialize_public = */ ssh_ed25519_serialize_public,
+	/* .generate = */	ssh_ed25519_generate,
 };
 
 const struct sshkey_impl sshkey_ed25519_impl = {

--- a/ssh-rsa.c
+++ b/ssh-rsa.c
@@ -32,6 +32,32 @@
 
 static int openssh_RSA_verify(int, u_char *, size_t, u_char *, size_t, RSA *);
 
+static u_int
+ssh_rsa_size(const struct sshkey *key)
+{
+	const BIGNUM *rsa_n;
+
+	if (key->rsa == NULL)
+		return 0;
+	RSA_get0_key(key->rsa, &rsa_n, NULL, NULL);
+	return BN_num_bits(rsa_n);
+}
+
+static int
+ssh_rsa_alloc(struct sshkey *k)
+{
+	if ((k->rsa = RSA_new()) == NULL)
+		return SSH_ERR_ALLOC_FAIL;
+	return 0;
+}
+
+static void
+ssh_rsa_cleanup(struct sshkey *k)
+{
+	RSA_free(k->rsa);
+	k->rsa = NULL;
+}
+
 static const char *
 rsa_hash_alg_ident(int hash_alg)
 {
@@ -439,3 +465,83 @@ done:
 	freezero(decrypted, rsasize);
 	return ret;
 }
+
+static const struct sshkey_impl_funcs sshkey_rsa_funcs = {
+	/* .size = */		ssh_rsa_size,
+	/* .alloc = */		ssh_rsa_alloc,
+	/* .cleanup = */	ssh_rsa_cleanup,
+};
+
+const struct sshkey_impl sshkey_rsa_impl = {
+	/* .name = */		"ssh-rsa",
+	/* .shortname = */	"RSA",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_RSA,
+	/* .nid = */		0,
+	/* .cert = */		0,
+	/* .sigonly = */	0,
+	/* .keybits = */	0,
+	/* .funcs = */		&sshkey_rsa_funcs,
+};
+
+const struct sshkey_impl sshkey_rsa_cert_impl = {
+	/* .name = */		"ssh-rsa-cert-v01@openssh.com",
+	/* .shortname = */	"RSA-CERT",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_RSA_CERT,
+	/* .nid = */		0,
+	/* .cert = */		1,
+	/* .sigonly = */	0,
+	/* .keybits = */	0,
+	/* .funcs = */		&sshkey_rsa_funcs,
+};
+
+/* SHA2 signature algorithms */
+
+const struct sshkey_impl sshkey_rsa_sha256_impl = {
+	/* .name = */		"rsa-sha2-256",
+	/* .shortname = */	"RSA",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_RSA,
+	/* .nid = */		0,
+	/* .cert = */		0,
+	/* .sigonly = */	1,
+	/* .keybits = */	0,
+	/* .funcs = */		&sshkey_rsa_funcs,
+};
+
+const struct sshkey_impl sshkey_rsa_sha512_impl = {
+	/* .name = */		"rsa-sha2-512",
+	/* .shortname = */	"RSA",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_RSA,
+	/* .nid = */		0,
+	/* .cert = */		0,
+	/* .sigonly = */	1,
+	/* .keybits = */	0,
+	/* .funcs = */		&sshkey_rsa_funcs,
+};
+
+const struct sshkey_impl sshkey_rsa_sha256_cert_impl = {
+	/* .name = */		"rsa-sha2-256-cert-v01@openssh.com",
+	/* .shortname = */	"RSA-CERT",
+	/* .sigalg = */		"rsa-sha2-256",
+	/* .type = */		KEY_RSA_CERT,
+	/* .nid = */		0,
+	/* .cert = */		1,
+	/* .sigonly = */	1,
+	/* .keybits = */	0,
+	/* .funcs = */		&sshkey_rsa_funcs,
+};
+
+const struct sshkey_impl sshkey_rsa_sha512_cert_impl = {
+	/* .name = */		"rsa-sha2-512-cert-v01@openssh.com",
+	/* .shortname = */	"RSA-CERT",
+	/* .sigalg = */		"rsa-sha2-512",
+	/* .type = */		KEY_RSA_CERT,
+	/* .nid = */		0,
+	/* .cert = */		1,
+	/* .sigonly = */	1,
+	/* .keybits = */	0,
+	/* .funcs = */		&sshkey_rsa_funcs,
+};

--- a/ssh-rsa.c
+++ b/ssh-rsa.c
@@ -226,6 +226,60 @@ ssh_rsa_deserialize_public(const char *ktype, struct sshbuf *b,
 	return ret;
 }
 
+static int
+ssh_rsa_deserialize_private(const char *ktype, struct sshbuf *b,
+    struct sshkey *key)
+{
+	int r;
+	BIGNUM *rsa_n = NULL, *rsa_e = NULL, *rsa_d = NULL;
+	BIGNUM *rsa_iqmp = NULL, *rsa_p = NULL, *rsa_q = NULL;
+
+	/* Note: can't reuse ssh_rsa_deserialize_public: e, n vs. n, e */
+	if (!sshkey_is_cert(key)) {
+		if ((r = sshbuf_get_bignum2(b, &rsa_n)) != 0 ||
+		    (r = sshbuf_get_bignum2(b, &rsa_e)) != 0)
+			goto out;
+		if (!RSA_set0_key(key->rsa, rsa_n, rsa_e, NULL)) {
+			r = SSH_ERR_LIBCRYPTO_ERROR;
+			goto out;
+		}
+		rsa_n = rsa_e = NULL; /* transferred */
+	}
+	if ((r = sshbuf_get_bignum2(b, &rsa_d)) != 0 ||
+	    (r = sshbuf_get_bignum2(b, &rsa_iqmp)) != 0 ||
+	    (r = sshbuf_get_bignum2(b, &rsa_p)) != 0 ||
+	    (r = sshbuf_get_bignum2(b, &rsa_q)) != 0)
+		goto out;
+	if (!RSA_set0_key(key->rsa, NULL, NULL, rsa_d)) {
+		r = SSH_ERR_LIBCRYPTO_ERROR;
+		goto out;
+	}
+	rsa_d = NULL; /* transferred */
+	if (!RSA_set0_factors(key->rsa, rsa_p, rsa_q)) {
+		r = SSH_ERR_LIBCRYPTO_ERROR;
+		goto out;
+	}
+	rsa_p = rsa_q = NULL; /* transferred */
+	if ((r = sshkey_check_rsa_length(key, 0)) != 0)
+		goto out;
+	if ((r = ssh_rsa_complete_crt_parameters(key, rsa_iqmp)) != 0)
+		goto out;
+	if (RSA_blinding_on(key->rsa, NULL) != 1) {
+		r = SSH_ERR_LIBCRYPTO_ERROR;
+		goto out;
+	}
+	/* success */
+	r = 0;
+ out:
+	BN_clear_free(rsa_n);
+	BN_clear_free(rsa_e);
+	BN_clear_free(rsa_d);
+	BN_clear_free(rsa_p);
+	BN_clear_free(rsa_q);
+	BN_clear_free(rsa_iqmp);
+	return r;
+}
+
 static const char *
 rsa_hash_alg_ident(int hash_alg)
 {
@@ -645,6 +699,7 @@ static const struct sshkey_impl_funcs sshkey_rsa_funcs = {
 	/* .ssh_serialize_public = */ ssh_rsa_serialize_public,
 	/* .ssh_deserialize_public = */ ssh_rsa_deserialize_public,
 	/* .ssh_serialize_private = */ ssh_rsa_serialize_private,
+	/* .ssh_deserialize_private = */ ssh_rsa_deserialize_private,
 	/* .generate = */	ssh_rsa_generate,
 	/* .copy_public = */	ssh_rsa_copy_public,
 	/* .sign = */		ssh_rsa_sign,

--- a/ssh-rsa.c
+++ b/ssh-rsa.c
@@ -58,6 +58,27 @@ ssh_rsa_cleanup(struct sshkey *k)
 	k->rsa = NULL;
 }
 
+static int
+ssh_rsa_equal(const struct sshkey *a, const struct sshkey *b)
+{
+	const BIGNUM *rsa_e_a, *rsa_n_a;
+	const BIGNUM *rsa_e_b, *rsa_n_b;
+
+	if (a->rsa == NULL || b->rsa == NULL)
+		return 0;
+	RSA_get0_key(a->rsa, &rsa_n_a, &rsa_e_a, NULL);
+	RSA_get0_key(b->rsa, &rsa_n_b, &rsa_e_b, NULL);
+	if (rsa_e_a == NULL || rsa_e_b == NULL)
+		return 0;
+	if (rsa_n_a == NULL || rsa_n_b == NULL)
+		return 0;
+	if (BN_cmp(rsa_e_a, rsa_e_b) != 0)
+		return 0;
+	if (BN_cmp(rsa_n_a, rsa_n_b) != 0)
+		return 0;
+	return 1;
+}
+
 static const char *
 rsa_hash_alg_ident(int hash_alg)
 {
@@ -470,6 +491,7 @@ static const struct sshkey_impl_funcs sshkey_rsa_funcs = {
 	/* .size = */		ssh_rsa_size,
 	/* .alloc = */		ssh_rsa_alloc,
 	/* .cleanup = */	ssh_rsa_cleanup,
+	/* .equal = */		ssh_rsa_equal,
 };
 
 const struct sshkey_impl sshkey_rsa_impl = {

--- a/ssh-rsa.c
+++ b/ssh-rsa.c
@@ -97,6 +97,34 @@ ssh_rsa_serialize_public(const struct sshkey *key, struct sshbuf *b,
 	return 0;
 }
 
+static int
+ssh_rsa_generate(struct sshkey *k, int bits)
+{
+	RSA *private = NULL;
+	BIGNUM *f4 = NULL;
+	int ret = SSH_ERR_INTERNAL_ERROR;
+
+	if (bits < SSH_RSA_MINIMUM_MODULUS_SIZE ||
+	    bits > SSHBUF_MAX_BIGNUM * 8)
+		return SSH_ERR_KEY_LENGTH;
+	if ((private = RSA_new()) == NULL || (f4 = BN_new()) == NULL) {
+		ret = SSH_ERR_ALLOC_FAIL;
+		goto out;
+	}
+	if (!BN_set_word(f4, RSA_F4) ||
+	    !RSA_generate_key_ex(private, bits, f4, NULL)) {
+		ret = SSH_ERR_LIBCRYPTO_ERROR;
+		goto out;
+	}
+	k->rsa = private;
+	private = NULL;
+	ret = 0;
+ out:
+	RSA_free(private);
+	BN_free(f4);
+	return ret;
+}
+
 static const char *
 rsa_hash_alg_ident(int hash_alg)
 {
@@ -511,6 +539,7 @@ static const struct sshkey_impl_funcs sshkey_rsa_funcs = {
 	/* .cleanup = */	ssh_rsa_cleanup,
 	/* .equal = */		ssh_rsa_equal,
 	/* .ssh_serialize_public = */ ssh_rsa_serialize_public,
+	/* .generate = */	ssh_rsa_generate,
 };
 
 const struct sshkey_impl sshkey_rsa_impl = {

--- a/ssh-rsa.c
+++ b/ssh-rsa.c
@@ -117,6 +117,32 @@ ssh_rsa_serialize_public(const struct sshkey *key, struct sshbuf *b,
 }
 
 static int
+ssh_rsa_serialize_private(const struct sshkey *key, struct sshbuf *b,
+    enum sshkey_serialize_rep opts)
+{
+	int r;
+	const BIGNUM *rsa_n, *rsa_e, *rsa_d, *rsa_iqmp, *rsa_p, *rsa_q;
+
+	RSA_get0_key(key->rsa, &rsa_n, &rsa_e, &rsa_d);
+	RSA_get0_factors(key->rsa, &rsa_p, &rsa_q);
+	RSA_get0_crt_params(key->rsa, NULL, NULL, &rsa_iqmp);
+
+	if (!sshkey_is_cert(key)) {
+		/* Note: can't reuse ssh_rsa_serialize_public: e, n vs. n, e */
+		if ((r = sshbuf_put_bignum2(b, rsa_n)) != 0 ||
+		    (r = sshbuf_put_bignum2(b, rsa_e)) != 0)
+			return r;
+	}
+	if ((r = sshbuf_put_bignum2(b, rsa_d)) != 0 ||
+	    (r = sshbuf_put_bignum2(b, rsa_iqmp)) != 0 ||
+	    (r = sshbuf_put_bignum2(b, rsa_p)) != 0 ||
+	    (r = sshbuf_put_bignum2(b, rsa_q)) != 0)
+		return r;
+
+	return 0;
+}
+
+static int
 ssh_rsa_generate(struct sshkey *k, int bits)
 {
 	RSA *private = NULL;
@@ -618,6 +644,7 @@ static const struct sshkey_impl_funcs sshkey_rsa_funcs = {
 	/* .equal = */		ssh_rsa_equal,
 	/* .ssh_serialize_public = */ ssh_rsa_serialize_public,
 	/* .ssh_deserialize_public = */ ssh_rsa_deserialize_public,
+	/* .ssh_serialize_private = */ ssh_rsa_serialize_private,
 	/* .generate = */	ssh_rsa_generate,
 	/* .copy_public = */	ssh_rsa_copy_public,
 	/* .sign = */		ssh_rsa_sign,

--- a/ssh-rsa.c
+++ b/ssh-rsa.c
@@ -32,6 +32,26 @@
 
 static int openssh_RSA_verify(int, u_char *, size_t, u_char *, size_t, RSA *);
 
+int
+sshkey_check_rsa_length(const struct sshkey *k, int min_size)
+{
+#ifdef WITH_OPENSSL
+	const BIGNUM *rsa_n;
+	int nbits;
+
+	if (k == NULL || k->rsa == NULL ||
+	    (k->type != KEY_RSA && k->type != KEY_RSA_CERT))
+		return 0;
+	RSA_get0_key(k->rsa, &rsa_n, NULL, NULL);
+	nbits = BN_num_bits(rsa_n);
+	if (nbits < SSH_RSA_MINIMUM_MODULUS_SIZE ||
+	    (min_size > 0 && nbits < min_size))
+		return SSH_ERR_KEY_LENGTH;
+#endif /* WITH_OPENSSL */
+	return 0;
+}
+
+
 static u_int
 ssh_rsa_size(const struct sshkey *key)
 {
@@ -81,7 +101,7 @@ ssh_rsa_equal(const struct sshkey *a, const struct sshkey *b)
 
 static int
 ssh_rsa_serialize_public(const struct sshkey *key, struct sshbuf *b,
-    const char *typename, enum sshkey_serialize_rep opts)
+    enum sshkey_serialize_rep opts)
 {
 	int r;
 	const BIGNUM *rsa_n, *rsa_e;
@@ -89,8 +109,7 @@ ssh_rsa_serialize_public(const struct sshkey *key, struct sshbuf *b,
 	if (key->rsa == NULL)
 		return SSH_ERR_INVALID_ARGUMENT;
 	RSA_get0_key(key->rsa, &rsa_n, &rsa_e, NULL);
-	if ((r = sshbuf_put_cstring(b, typename)) != 0 ||
-	    (r = sshbuf_put_bignum2(b, rsa_e)) != 0 ||
+	if ((r = sshbuf_put_bignum2(b, rsa_e)) != 0 ||
 	    (r = sshbuf_put_bignum2(b, rsa_n)) != 0)
 		return r;
 
@@ -149,6 +168,36 @@ ssh_rsa_copy_public(const struct sshkey *from, struct sshkey *to)
 	BN_clear_free(rsa_n_dup);
 	BN_clear_free(rsa_e_dup);
 	return r;
+}
+
+static int
+ssh_rsa_deserialize_public(const char *ktype, struct sshbuf *b,
+    struct sshkey *key)
+{
+	int ret = SSH_ERR_INTERNAL_ERROR;
+	BIGNUM *rsa_n = NULL, *rsa_e = NULL;
+
+	if (sshbuf_get_bignum2(b, &rsa_e) != 0 ||
+	    sshbuf_get_bignum2(b, &rsa_n) != 0) {
+		ret = SSH_ERR_INVALID_FORMAT;
+		goto out;
+	}
+	if (!RSA_set0_key(key->rsa, rsa_n, rsa_e, NULL)) {
+		ret = SSH_ERR_LIBCRYPTO_ERROR;
+		goto out;
+	}
+	rsa_n = rsa_e = NULL; /* transferred */
+	if ((ret = sshkey_check_rsa_length(key, 0)) != 0)
+		goto out;
+#ifdef DEBUG_PK
+	RSA_print_fp(stderr, key->rsa, 8);
+#endif
+	/* success */
+	ret = 0;
+ out:
+	BN_clear_free(rsa_n);
+	BN_clear_free(rsa_e);
+	return ret;
 }
 
 static const char *
@@ -565,6 +614,7 @@ static const struct sshkey_impl_funcs sshkey_rsa_funcs = {
 	/* .cleanup = */	ssh_rsa_cleanup,
 	/* .equal = */		ssh_rsa_equal,
 	/* .ssh_serialize_public = */ ssh_rsa_serialize_public,
+	/* .ssh_deserialize_public = */ ssh_rsa_deserialize_public,
 	/* .generate = */	ssh_rsa_generate,
 	/* .copy_public = */	ssh_rsa_copy_public,
 };

--- a/ssh-rsa.c
+++ b/ssh-rsa.c
@@ -79,6 +79,24 @@ ssh_rsa_equal(const struct sshkey *a, const struct sshkey *b)
 	return 1;
 }
 
+static int
+ssh_rsa_serialize_public(const struct sshkey *key, struct sshbuf *b,
+    const char *typename, enum sshkey_serialize_rep opts)
+{
+	int r;
+	const BIGNUM *rsa_n, *rsa_e;
+
+	if (key->rsa == NULL)
+		return SSH_ERR_INVALID_ARGUMENT;
+	RSA_get0_key(key->rsa, &rsa_n, &rsa_e, NULL);
+	if ((r = sshbuf_put_cstring(b, typename)) != 0 ||
+	    (r = sshbuf_put_bignum2(b, rsa_e)) != 0 ||
+	    (r = sshbuf_put_bignum2(b, rsa_n)) != 0)
+		return r;
+
+	return 0;
+}
+
 static const char *
 rsa_hash_alg_ident(int hash_alg)
 {
@@ -492,6 +510,7 @@ static const struct sshkey_impl_funcs sshkey_rsa_funcs = {
 	/* .alloc = */		ssh_rsa_alloc,
 	/* .cleanup = */	ssh_rsa_cleanup,
 	/* .equal = */		ssh_rsa_equal,
+	/* .ssh_serialize_public = */ ssh_rsa_serialize_public,
 };
 
 const struct sshkey_impl sshkey_rsa_impl = {

--- a/ssh-rsa.c
+++ b/ssh-rsa.c
@@ -321,14 +321,16 @@ ssh_rsa_complete_crt_parameters(struct sshkey *key, const BIGNUM *iqmp)
 }
 
 /* RSASSA-PKCS1-v1_5 (PKCS #1 v2.0 signature) with SHA1 */
-int
-ssh_rsa_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
-    const u_char *data, size_t datalen, const char *alg_ident)
+static int
+ssh_rsa_sign(struct sshkey *key,
+    u_char **sigp, size_t *lenp,
+    const u_char *data, size_t datalen,
+    const char *alg, const char *sk_provider, const char *sk_pin, u_int compat)
 {
 	const BIGNUM *rsa_n;
 	u_char digest[SSH_DIGEST_MAX_LENGTH], *sig = NULL;
 	size_t slen = 0;
-	u_int dlen, len;
+	u_int hlen, len;
 	int nid, hash_alg, ret = SSH_ERR_INTERNAL_ERROR;
 	struct sshbuf *b = NULL;
 
@@ -337,10 +339,10 @@ ssh_rsa_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
 	if (sigp != NULL)
 		*sigp = NULL;
 
-	if (alg_ident == NULL || strlen(alg_ident) == 0)
+	if (alg == NULL || strlen(alg) == 0)
 		hash_alg = SSH_DIGEST_SHA1;
 	else
-		hash_alg = rsa_hash_id_from_keyname(alg_ident);
+		hash_alg = rsa_hash_id_from_keyname(alg);
 	if (key == NULL || key->rsa == NULL || hash_alg == -1 ||
 	    sshkey_type_plain(key->type) != KEY_RSA)
 		return SSH_ERR_INVALID_ARGUMENT;
@@ -353,7 +355,7 @@ ssh_rsa_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
 
 	/* hash the data */
 	nid = rsa_hash_alg_nid(hash_alg);
-	if ((dlen = ssh_digest_bytes(hash_alg)) == 0)
+	if ((hlen = ssh_digest_bytes(hash_alg)) == 0)
 		return SSH_ERR_INTERNAL_ERROR;
 	if ((ret = ssh_digest_memory(hash_alg, data, datalen,
 	    digest, sizeof(digest))) != 0)
@@ -364,7 +366,7 @@ ssh_rsa_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
 		goto out;
 	}
 
-	if (RSA_sign(nid, digest, dlen, sig, &len, key->rsa) != 1) {
+	if (RSA_sign(nid, digest, hlen, sig, &len, key->rsa) != 1) {
 		ret = SSH_ERR_LIBCRYPTO_ERROR;
 		goto out;
 	}
@@ -402,15 +404,16 @@ ssh_rsa_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
 	return ret;
 }
 
-int
+static int
 ssh_rsa_verify(const struct sshkey *key,
-    const u_char *sig, size_t siglen, const u_char *data, size_t datalen,
-    const char *alg)
+    const u_char *sig, size_t siglen,
+    const u_char *data, size_t dlen, const char *alg, u_int compat,
+    struct sshkey_sig_details **detailsp)
 {
 	const BIGNUM *rsa_n;
 	char *sigtype = NULL;
 	int hash_alg, want_alg, ret = SSH_ERR_INTERNAL_ERROR;
-	size_t len = 0, diff, modlen, dlen;
+	size_t len = 0, diff, modlen, hlen;
 	struct sshbuf *b = NULL;
 	u_char digest[SSH_DIGEST_MAX_LENGTH], *osigblob, *sigblob = NULL;
 
@@ -471,15 +474,15 @@ ssh_rsa_verify(const struct sshkey *key,
 		explicit_bzero(sigblob, diff);
 		len = modlen;
 	}
-	if ((dlen = ssh_digest_bytes(hash_alg)) == 0) {
+	if ((hlen = ssh_digest_bytes(hash_alg)) == 0) {
 		ret = SSH_ERR_INTERNAL_ERROR;
 		goto out;
 	}
-	if ((ret = ssh_digest_memory(hash_alg, data, datalen,
+	if ((ret = ssh_digest_memory(hash_alg, data, dlen,
 	    digest, sizeof(digest))) != 0)
 		goto out;
 
-	ret = openssh_RSA_verify(hash_alg, digest, dlen, sigblob, len,
+	ret = openssh_RSA_verify(hash_alg, digest, hlen, sigblob, len,
 	    key->rsa);
  out:
 	freezero(sigblob, len);
@@ -617,6 +620,8 @@ static const struct sshkey_impl_funcs sshkey_rsa_funcs = {
 	/* .ssh_deserialize_public = */ ssh_rsa_deserialize_public,
 	/* .generate = */	ssh_rsa_generate,
 	/* .copy_public = */	ssh_rsa_copy_public,
+	/* .sign = */		ssh_rsa_sign,
+	/* .verify = */		ssh_rsa_verify,
 };
 
 const struct sshkey_impl sshkey_rsa_impl = {

--- a/ssh-xmss.c
+++ b/ssh-xmss.c
@@ -156,6 +156,43 @@ ssh_xmss_deserialize_public(const char *ktype, struct sshbuf *b,
 }
 
 static int
+ssh_xmss_deserialize_private(const char *ktype, struct sshbuf *b,
+    struct sshkey *key)
+{
+	int r;
+	char *xmss_name = NULL;
+	size_t pklen = 0, sklen = 0;
+	u_char *xmss_pk = NULL, *xmss_sk = NULL;
+
+	/* Note: can't reuse ssh_xmss_deserialize_public because of sk order */
+	if ((r = sshbuf_get_cstring(b, &xmss_name, NULL)) != 0 ||
+	    (r = sshbuf_get_string(b, &xmss_pk, &pklen)) != 0 ||
+	    (r = sshbuf_get_string(b, &xmss_sk, &sklen)) != 0)
+		goto out;
+	if (!sshkey_is_cert(key) &&
+	    (r = sshkey_xmss_init(key, xmss_name)) != 0)
+		goto out;
+	if (pklen != sshkey_xmss_pklen(key) ||
+	    sklen != sshkey_xmss_sklen(key)) {
+		r = SSH_ERR_INVALID_FORMAT;
+		goto out;
+	}
+	key->xmss_pk = xmss_pk;
+	key->xmss_sk = xmss_sk;
+	xmss_pk = xmss_sk = NULL;
+	/* optional internal state */
+	if ((r = sshkey_xmss_deserialize_state_opt(key, b)) != 0)
+		goto out;
+	/* success */
+	r = 0;
+ out:
+	free(xmss_name);
+	freezero(xmss_pk, pklen);
+	freezero(xmss_sk, sklen);
+	return r;
+}
+
+static int
 ssh_xmss_sign(struct sshkey *key,
     u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen,
@@ -314,6 +351,7 @@ static const struct sshkey_impl_funcs sshkey_xmss_funcs = {
 	/* .ssh_serialize_public = */ ssh_xmss_serialize_public,
 	/* .ssh_deserialize_public = */ ssh_xmss_deserialize_public,
 	/* .ssh_serialize_private = */ ssh_xmss_serialize_private,
+	/* .ssh_deserialize_private = */ ssh_xmss_deserialize_private,
 	/* .generate = */	sshkey_xmss_generate_private_key,
 	/* .copy_public = */	ssh_xmss_copy_publie,
 	/* .sign = */		ssh_xmss_sign,

--- a/ssh-xmss.c
+++ b/ssh-xmss.c
@@ -34,6 +34,20 @@
 
 #include "xmss_fast.h"
 
+static void
+ssh_xmss_cleanup(struct sshkey *k)
+{
+	freezero(k->xmss_pk, sshkey_xmss_pklen(k));
+	freezero(k->xmss_sk, sshkey_xmss_sklen(k));
+	sshkey_xmss_free_state(k);
+	free(k->xmss_name);
+	free(k->xmss_filename);
+	k->xmss_pk = NULL;
+	k->xmss_sk = NULL;
+	k->xmss_name = NULL;
+	k->xmss_filename = NULL;
+}
+
 int
 ssh_xmss_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen, u_int compat)
@@ -181,3 +195,33 @@ ssh_xmss_verify(const struct sshkey *key,
 	free(ktype);
 	return r;
 }
+
+static const struct sshkey_impl_funcs sshkey_xmss_funcs = {
+	/* .size = */		NULL,
+	/* .alloc = */		NULL,
+	/* .cleanup = */	ssh_xmss_cleanup,
+};
+
+const struct sshkey_impl sshkey_xmss_impl = {
+	/* .name = */		"ssh-xmss@openssh.com",
+	/* .shortname = */	"XMSS",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_XMSS,
+	/* .nid = */		0,
+	/* .cert = */		0,
+	/* .sigonly = */	0,
+	/* .keybits = */	256,
+	/* .funcs = */		&sshkey_xmss_funcs,
+};
+
+const struct sshkey_impl sshkey_xmss_cert_impl = {
+	/* .name = */		"ssh-xmss-cert-v01@openssh.com",
+	/* .shortname = */	"XMSS-CERT",
+	/* .sigalg = */		NULL,
+	/* .type = */		KEY_XMSS_CERT,
+	/* .nid = */		0,
+	/* .cert = */		1,
+	/* .sigonly = */	0,
+	/* .keybits = */	256,
+	/* .funcs = */		&sshkey_xmss_funcs,
+};

--- a/ssh-xmss.c
+++ b/ssh-xmss.c
@@ -135,9 +135,11 @@ ssh_xmss_deserialize_public(const char *ktype, struct sshbuf *b,
 	return ret;
 }
 
-int
-ssh_xmss_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
-    const u_char *data, size_t datalen, u_int compat)
+static int
+ssh_xmss_sign(struct sshkey *key,
+    u_char **sigp, size_t *lenp,
+    const u_char *data, size_t datalen,
+    const char *alg, const char *sk_provider, const char *sk_pin, u_int compat)
 {
 	u_char *sig = NULL;
 	size_t slen = 0, len = 0, required_siglen;
@@ -209,10 +211,11 @@ ssh_xmss_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
 	return r;
 }
 
-int
+static int
 ssh_xmss_verify(const struct sshkey *key,
-    const u_char *signature, size_t signaturelen,
-    const u_char *data, size_t datalen, u_int compat)
+    const u_char *sig, size_t siglen,
+    const u_char *data, size_t dlen, const char *alg, u_int compat,
+    struct sshkey_sig_details **detailsp)
 {
 	struct sshbuf *b = NULL;
 	char *ktype = NULL;
@@ -292,6 +295,8 @@ static const struct sshkey_impl_funcs sshkey_xmss_funcs = {
 	/* .ssh_deserialize_public = */ ssh_xmss_deserialize_public,
 	/* .generate = */	sshkey_xmss_generate_private_key,
 	/* .copy_public = */	ssh_xmss_copy_publie,
+	/* .sign = */		ssh_xmss_sign,
+	/* .verify = */		ssh_xmss_verify,
 };
 
 const struct sshkey_impl sshkey_xmss_impl = {

--- a/ssh-xmss.c
+++ b/ssh-xmss.c
@@ -62,15 +62,14 @@ ssh_xmss_equal(const struct sshkey *a, const struct sshkey *b)
 
 static int
 ssh_xmss_serialize_public(const struct sshkey *key, struct sshbuf *b,
-    const char *typename, enum sshkey_serialize_rep opts)
+    enum sshkey_serialize_rep opts)
 {
 	int r;
 
 	if (key->xmss_name == NULL || key->xmss_pk == NULL ||
 	    sshkey_xmss_pklen(key) == 0)
 		return SSH_ERR_INVALID_ARGUMENT;
-	if ((r = sshbuf_put_cstring(b, typename)) != 0 ||
-	    (r = sshbuf_put_cstring(b, key->xmss_name)) != 0 ||
+	if ((r = sshbuf_put_cstring(b, key->xmss_name)) != 0 ||
 	    (r = sshbuf_put_string(b, key->xmss_pk,
 	    sshkey_xmss_pklen(key))) != 0 ||
 	    (r = sshkey_xmss_serialize_pk_info(key, b, opts)) != 0)
@@ -102,6 +101,38 @@ ssh_xmss_copy_public(const struct sshkey *from, struct sshkey *to)
 	if (left)
 		sshkey_xmss_enable_maxsign(n, left);
 	return 0;
+}
+
+static int
+ssh_xmss_deserialize_public(const char *ktype, struct sshbuf *b,
+    struct sshkey *key)
+{
+	size_t len = 0;
+	char *xmss_name = NULL;
+	u_char *pk = NULL;
+	int ret = SSH_ERR_INTERNAL_ERROR;
+
+	if ((ret = sshbuf_get_cstring(b, &xmss_name, NULL)) != 0)
+		goto out;
+	if ((ret = sshkey_xmss_init(key, xmss_name)) != 0)
+		goto out;
+	if ((ret = sshbuf_get_string(b, &pk, &len)) != 0)
+		goto out;
+	if (len == 0 || len != sshkey_xmss_pklen(key)) {
+		ret = SSH_ERR_INVALID_FORMAT;
+		goto out;
+	}
+	key->xmss_pk = pk;
+	pk = NULL;
+	if (!sshkey_is_cert(key) &&
+	    (ret = sshkey_xmss_deserialize_pk_info(key, b)) != 0)
+		goto out;
+	/* success */
+	ret = 0;
+ out:
+	free(xmss_name);
+	freezero(pk, len);
+	return ret;
 }
 
 int
@@ -258,6 +289,7 @@ static const struct sshkey_impl_funcs sshkey_xmss_funcs = {
 	/* .cleanup = */	ssh_xmss_cleanup,
 	/* .equal = */		ssh_xmss_equal,
 	/* .ssh_serialize_public = */ ssh_xmss_serialize_public,
+	/* .ssh_deserialize_public = */ ssh_xmss_deserialize_public,
 	/* .generate = */	sshkey_xmss_generate_private_key,
 	/* .copy_public = */	ssh_xmss_copy_publie,
 };

--- a/ssh-xmss.c
+++ b/ssh-xmss.c
@@ -233,6 +233,7 @@ static const struct sshkey_impl_funcs sshkey_xmss_funcs = {
 	/* .cleanup = */	ssh_xmss_cleanup,
 	/* .equal = */		ssh_xmss_equal,
 	/* .ssh_serialize_public = */ ssh_xmss_serialize_public,
+	/* .generate = */	sshkey_xmss_generate_private_key,
 };
 
 const struct sshkey_impl sshkey_xmss_impl = {

--- a/ssh-xmss.c
+++ b/ssh-xmss.c
@@ -79,6 +79,26 @@ ssh_xmss_serialize_public(const struct sshkey *key, struct sshbuf *b,
 }
 
 static int
+ssh_xmss_serialize_private(const struct sshkey *key, struct sshbuf *b,
+    enum sshkey_serialize_rep opts)
+{
+	int r;
+
+	if (key->xmss_name == NULL)
+		return SSH_ERR_INVALID_ARGUMENT;
+	/* Note: can't reuse ssh_xmss_serialize_public because of sk order */
+	if ((r = sshbuf_put_cstring(b, key->xmss_name)) != 0 ||
+	    (r = sshbuf_put_string(b, key->xmss_pk,
+	    sshkey_xmss_pklen(key))) != 0 ||
+	    (r = sshbuf_put_string(b, key->xmss_sk,
+	    sshkey_xmss_sklen(key))) != 0 ||
+	    (r = sshkey_xmss_serialize_state_opt(key, b, opts)) != 0)
+		return r;
+
+	return 0;
+}
+
+static int
 ssh_xmss_copy_public(const struct sshkey *from, struct sshkey *to)
 {
 	int r = SSH_ERR_INTERNAL_ERROR;
@@ -293,6 +313,7 @@ static const struct sshkey_impl_funcs sshkey_xmss_funcs = {
 	/* .equal = */		ssh_xmss_equal,
 	/* .ssh_serialize_public = */ ssh_xmss_serialize_public,
 	/* .ssh_deserialize_public = */ ssh_xmss_deserialize_public,
+	/* .ssh_serialize_private = */ ssh_xmss_serialize_private,
 	/* .generate = */	sshkey_xmss_generate_private_key,
 	/* .copy_public = */	ssh_xmss_copy_publie,
 	/* .sign = */		ssh_xmss_sign,

--- a/ssh-xmss.c
+++ b/ssh-xmss.c
@@ -60,6 +60,25 @@ ssh_xmss_equal(const struct sshkey *a, const struct sshkey *b)
 	return 1;
 }
 
+static int
+ssh_xmss_serialize_public(const struct sshkey *key, struct sshbuf *b,
+    const char *typename, enum sshkey_serialize_rep opts)
+{
+	int r;
+
+	if (key->xmss_name == NULL || key->xmss_pk == NULL ||
+	    sshkey_xmss_pklen(key) == 0)
+		return SSH_ERR_INVALID_ARGUMENT;
+	if ((r = sshbuf_put_cstring(b, typename)) != 0 ||
+	    (r = sshbuf_put_cstring(b, key->xmss_name)) != 0 ||
+	    (r = sshbuf_put_string(b, key->xmss_pk,
+	    sshkey_xmss_pklen(key))) != 0 ||
+	    (r = sshkey_xmss_serialize_pk_info(key, b, opts)) != 0)
+		return r;
+
+	return 0
+}
+
 int
 ssh_xmss_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen, u_int compat)
@@ -213,6 +232,7 @@ static const struct sshkey_impl_funcs sshkey_xmss_funcs = {
 	/* .alloc = */		NULL,
 	/* .cleanup = */	ssh_xmss_cleanup,
 	/* .equal = */		ssh_xmss_equal,
+	/* .ssh_serialize_public = */ ssh_xmss_serialize_public,
 };
 
 const struct sshkey_impl sshkey_xmss_impl = {

--- a/ssh-xmss.c
+++ b/ssh-xmss.c
@@ -48,6 +48,18 @@ ssh_xmss_cleanup(struct sshkey *k)
 	k->xmss_filename = NULL;
 }
 
+static int
+ssh_xmss_equal(const struct sshkey *a, const struct sshkey *b)
+{
+	if (a->xmss_pk == NULL || b->xmss_pk == NULL)
+		return 0;
+	if (sshkey_xmss_pklen(a) != sshkey_xmss_pklen(b))
+		return 0;
+	if (memcmp(a->xmss_pk, b->xmss_pk, sshkey_xmss_pklen(a)) != 0)
+		return 0;
+	return 1;
+}
+
 int
 ssh_xmss_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen, u_int compat)
@@ -200,6 +212,7 @@ static const struct sshkey_impl_funcs sshkey_xmss_funcs = {
 	/* .size = */		NULL,
 	/* .alloc = */		NULL,
 	/* .cleanup = */	ssh_xmss_cleanup,
+	/* .equal = */		ssh_xmss_equal,
 };
 
 const struct sshkey_impl sshkey_xmss_impl = {

--- a/ssh-xmss.c
+++ b/ssh-xmss.c
@@ -79,6 +79,31 @@ ssh_xmss_serialize_public(const struct sshkey *key, struct sshbuf *b,
 	return 0
 }
 
+static int
+ssh_xmss_copy_public(const struct sshkey *from, struct sshkey *to)
+{
+	int r = SSH_ERR_INTERNAL_ERROR;
+	u_int32_t left;
+	size_t pklen;
+
+	if ((r = sshkey_xmss_init(n, from->xmss_name)) != 0)
+		goto out;
+	if (from->xmss_pk == NULL)
+		return 0; /* XXX SSH_ERR_INTERNAL_ERROR ? */
+
+	if ((pklen = sshkey_xmss_pklen(k)) == 0 ||
+	    sshkey_xmss_pklen(n) != pklen)
+		return SSH_ERR_INTERNAL_ERROR;
+	if ((to->xmss_pk = malloc(pklen)) == NULL)
+		return SSH_ERR_ALLOC_FAIL; /* caller will free to->xmss_pk */
+	memcpy(to->xmss_pk, from->xmss_pk, pklen);
+	/* simulate number of signatures left on pubkey */
+	left = sshkey_xmss_signatures_left(k);
+	if (left)
+		sshkey_xmss_enable_maxsign(n, left);
+	return 0;
+}
+
 int
 ssh_xmss_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen, u_int compat)
@@ -234,6 +259,7 @@ static const struct sshkey_impl_funcs sshkey_xmss_funcs = {
 	/* .equal = */		ssh_xmss_equal,
 	/* .ssh_serialize_public = */ ssh_xmss_serialize_public,
 	/* .generate = */	sshkey_xmss_generate_private_key,
+	/* .copy_public = */	ssh_xmss_copy_publie,
 };
 
 const struct sshkey_impl sshkey_xmss_impl = {

--- a/sshd.c
+++ b/sshd.c
@@ -1426,7 +1426,7 @@ accumulate_host_timing_secret(struct sshbuf *server_cfg,
 	if ((buf = sshbuf_new()) == NULL)
 		fatal_f("could not allocate buffer");
 	if ((r = sshkey_private_serialize(key, buf)) != 0)
-		fatal_fr(r, "decode key");
+		fatal_fr(r, "encode %s key", sshkey_ssh_name(key));
 	if (ssh_digest_update(ctx, sshbuf_ptr(buf), sshbuf_len(buf)) != 0)
 		fatal_f("ssh_digest_update");
 	sshbuf_reset(buf);

--- a/sshkey.c
+++ b/sshkey.c
@@ -567,6 +567,17 @@ sshkey_new(int type)
 	return k;
 }
 
+/* Frees common FIDO fields */
+void
+sshkey_sk_cleanup(struct sshkey *k)
+{
+	free(k->sk_application);
+	sshbuf_free(k->sk_key_handle);
+	sshbuf_free(k->sk_reserved);
+	k->sk_application = NULL;
+	k->sk_key_handle = k->sk_reserved = NULL;
+}
+
 void
 sshkey_free(struct sshkey *k)
 {
@@ -599,6 +610,17 @@ cert_compare(struct sshkey_cert *a, struct sshkey_cert *b)
 	return 1;
 }
 
+/* Compares FIDO-specific pubkey fields only */
+int
+sshkey_sk_fields_equal(const struct sshkey *a, const struct sshkey *b)
+{
+	if (a->sk_application == NULL || b->sk_application == NULL)
+		return 0;
+	if (strcmp(a->sk_application, b->sk_application) != 0)
+		return 0;
+	return 1;
+}
+
 /*
  * Compare public portions of key only, allowing comparisons between
  * certificates and plain keys too.
@@ -606,82 +628,14 @@ cert_compare(struct sshkey_cert *a, struct sshkey_cert *b)
 int
 sshkey_equal_public(const struct sshkey *a, const struct sshkey *b)
 {
-#ifdef WITH_OPENSSL
-	const BIGNUM *rsa_e_a, *rsa_n_a;
-	const BIGNUM *rsa_e_b, *rsa_n_b;
-	const BIGNUM *dsa_p_a, *dsa_q_a, *dsa_g_a, *dsa_pub_key_a;
-	const BIGNUM *dsa_p_b, *dsa_q_b, *dsa_g_b, *dsa_pub_key_b;
-#endif /* WITH_OPENSSL */
+	const struct sshkey_impl *impl;
 
 	if (a == NULL || b == NULL ||
 	    sshkey_type_plain(a->type) != sshkey_type_plain(b->type))
 		return 0;
-
-	switch (a->type) {
-#ifdef WITH_OPENSSL
-	case KEY_RSA_CERT:
-	case KEY_RSA:
-		if (a->rsa == NULL || b->rsa == NULL)
-			return 0;
-		RSA_get0_key(a->rsa, &rsa_n_a, &rsa_e_a, NULL);
-		RSA_get0_key(b->rsa, &rsa_n_b, &rsa_e_b, NULL);
-		return BN_cmp(rsa_e_a, rsa_e_b) == 0 &&
-		    BN_cmp(rsa_n_a, rsa_n_b) == 0;
-	case KEY_DSA_CERT:
-	case KEY_DSA:
-		if (a->dsa == NULL || b->dsa == NULL)
-			return 0;
-		DSA_get0_pqg(a->dsa, &dsa_p_a, &dsa_q_a, &dsa_g_a);
-		DSA_get0_pqg(b->dsa, &dsa_p_b, &dsa_q_b, &dsa_g_b);
-		DSA_get0_key(a->dsa, &dsa_pub_key_a, NULL);
-		DSA_get0_key(b->dsa, &dsa_pub_key_b, NULL);
-		return BN_cmp(dsa_p_a, dsa_p_b) == 0 &&
-		    BN_cmp(dsa_q_a, dsa_q_b) == 0 &&
-		    BN_cmp(dsa_g_a, dsa_g_b) == 0 &&
-		    BN_cmp(dsa_pub_key_a, dsa_pub_key_b) == 0;
-	case KEY_ECDSA_SK:
-	case KEY_ECDSA_SK_CERT:
-		if (a->sk_application == NULL || b->sk_application == NULL)
-			return 0;
-		if (strcmp(a->sk_application, b->sk_application) != 0)
-			return 0;
-		/* FALLTHROUGH */
-	case KEY_ECDSA_CERT:
-	case KEY_ECDSA:
-		if (a->ecdsa == NULL || b->ecdsa == NULL ||
-		    EC_KEY_get0_public_key(a->ecdsa) == NULL ||
-		    EC_KEY_get0_public_key(b->ecdsa) == NULL)
-			return 0;
-		if (EC_GROUP_cmp(EC_KEY_get0_group(a->ecdsa),
-		    EC_KEY_get0_group(b->ecdsa), NULL) != 0 ||
-		    EC_POINT_cmp(EC_KEY_get0_group(a->ecdsa),
-		    EC_KEY_get0_public_key(a->ecdsa),
-		    EC_KEY_get0_public_key(b->ecdsa), NULL) != 0)
-			return 0;
-		return 1;
-#endif /* WITH_OPENSSL */
-	case KEY_ED25519_SK:
-	case KEY_ED25519_SK_CERT:
-		if (a->sk_application == NULL || b->sk_application == NULL)
-			return 0;
-		if (strcmp(a->sk_application, b->sk_application) != 0)
-			return 0;
-		/* FALLTHROUGH */
-	case KEY_ED25519:
-	case KEY_ED25519_CERT:
-		return a->ed25519_pk != NULL && b->ed25519_pk != NULL &&
-		    memcmp(a->ed25519_pk, b->ed25519_pk, ED25519_PK_SZ) == 0;
-#ifdef WITH_XMSS
-	case KEY_XMSS:
-	case KEY_XMSS_CERT:
-		return a->xmss_pk != NULL && b->xmss_pk != NULL &&
-		    sshkey_xmss_pklen(a) == sshkey_xmss_pklen(b) &&
-		    memcmp(a->xmss_pk, b->xmss_pk, sshkey_xmss_pklen(a)) == 0;
-#endif /* WITH_XMSS */
-	default:
+	if ((impl = sshkey_impl_from_type(a->type)) == NULL)
 		return 0;
-	}
-	/* NOTREACHED */
+	return impl->funcs->equal(a, b);
 }
 
 int

--- a/sshkey.c
+++ b/sshkey.c
@@ -650,114 +650,47 @@ sshkey_equal(const struct sshkey *a, const struct sshkey *b)
 	return sshkey_equal_public(a, b);
 }
 
+
+/* Serialise common FIDO key parts */
+int
+sshkey_serialize_sk(const struct sshkey *key, struct sshbuf *b)
+{
+	int r;
+
+	if ((r = sshbuf_put_cstring(b, key->sk_application)) != 0)
+		return r;
+
+	return 0;
+}
+
 static int
 to_blob_buf(const struct sshkey *key, struct sshbuf *b, int force_plain,
   enum sshkey_serialize_rep opts)
 {
 	int type, ret = SSH_ERR_INTERNAL_ERROR;
 	const char *typename;
-#ifdef WITH_OPENSSL
-	const BIGNUM *rsa_n, *rsa_e, *dsa_p, *dsa_q, *dsa_g, *dsa_pub_key;
-#endif /* WITH_OPENSSL */
+	const struct sshkey_impl *impl;
 
 	if (key == NULL)
 		return SSH_ERR_INVALID_ARGUMENT;
 
-	if (sshkey_is_cert(key)) {
+	type = force_plain ? sshkey_type_plain(key->type) : key->type;
+
+	if (sshkey_type_is_cert(type)) {
 		if (key->cert == NULL)
 			return SSH_ERR_EXPECTED_CERT;
 		if (sshbuf_len(key->cert->certblob) == 0)
 			return SSH_ERR_KEY_LACKS_CERTBLOB;
-	}
-	type = force_plain ? sshkey_type_plain(key->type) : key->type;
-	typename = sshkey_ssh_name_from_type_nid(type, key->ecdsa_nid);
-
-	switch (type) {
-#ifdef WITH_OPENSSL
-	case KEY_DSA_CERT:
-	case KEY_ECDSA_CERT:
-	case KEY_ECDSA_SK_CERT:
-	case KEY_RSA_CERT:
-#endif /* WITH_OPENSSL */
-	case KEY_ED25519_CERT:
-	case KEY_ED25519_SK_CERT:
-#ifdef WITH_XMSS
-	case KEY_XMSS_CERT:
-#endif /* WITH_XMSS */
 		/* Use the existing blob */
-		/* XXX modified flag? */
 		if ((ret = sshbuf_putb(b, key->cert->certblob)) != 0)
 			return ret;
-		break;
-#ifdef WITH_OPENSSL
-	case KEY_DSA:
-		if (key->dsa == NULL)
-			return SSH_ERR_INVALID_ARGUMENT;
-		DSA_get0_pqg(key->dsa, &dsa_p, &dsa_q, &dsa_g);
-		DSA_get0_key(key->dsa, &dsa_pub_key, NULL);
-		if ((ret = sshbuf_put_cstring(b, typename)) != 0 ||
-		    (ret = sshbuf_put_bignum2(b, dsa_p)) != 0 ||
-		    (ret = sshbuf_put_bignum2(b, dsa_q)) != 0 ||
-		    (ret = sshbuf_put_bignum2(b, dsa_g)) != 0 ||
-		    (ret = sshbuf_put_bignum2(b, dsa_pub_key)) != 0)
-			return ret;
-		break;
-	case KEY_ECDSA:
-	case KEY_ECDSA_SK:
-		if (key->ecdsa == NULL)
-			return SSH_ERR_INVALID_ARGUMENT;
-		if ((ret = sshbuf_put_cstring(b, typename)) != 0 ||
-		    (ret = sshbuf_put_cstring(b,
-		    sshkey_curve_nid_to_name(key->ecdsa_nid))) != 0 ||
-		    (ret = sshbuf_put_eckey(b, key->ecdsa)) != 0)
-			return ret;
-		if (type == KEY_ECDSA_SK) {
-			if ((ret = sshbuf_put_cstring(b,
-			    key->sk_application)) != 0)
-				return ret;
-		}
-		break;
-	case KEY_RSA:
-		if (key->rsa == NULL)
-			return SSH_ERR_INVALID_ARGUMENT;
-		RSA_get0_key(key->rsa, &rsa_n, &rsa_e, NULL);
-		if ((ret = sshbuf_put_cstring(b, typename)) != 0 ||
-		    (ret = sshbuf_put_bignum2(b, rsa_e)) != 0 ||
-		    (ret = sshbuf_put_bignum2(b, rsa_n)) != 0)
-			return ret;
-		break;
-#endif /* WITH_OPENSSL */
-	case KEY_ED25519:
-	case KEY_ED25519_SK:
-		if (key->ed25519_pk == NULL)
-			return SSH_ERR_INVALID_ARGUMENT;
-		if ((ret = sshbuf_put_cstring(b, typename)) != 0 ||
-		    (ret = sshbuf_put_string(b,
-		    key->ed25519_pk, ED25519_PK_SZ)) != 0)
-			return ret;
-		if (type == KEY_ED25519_SK) {
-			if ((ret = sshbuf_put_cstring(b,
-			    key->sk_application)) != 0)
-				return ret;
-		}
-		break;
-#ifdef WITH_XMSS
-	case KEY_XMSS:
-		if (key->xmss_name == NULL || key->xmss_pk == NULL ||
-		    sshkey_xmss_pklen(key) == 0)
-			return SSH_ERR_INVALID_ARGUMENT;
-		if ((ret = sshbuf_put_cstring(b, typename)) != 0 ||
-		    (ret = sshbuf_put_cstring(b, key->xmss_name)) != 0 ||
-		    (ret = sshbuf_put_string(b,
-		    key->xmss_pk, sshkey_xmss_pklen(key))) != 0 ||
-		    (ret = sshkey_xmss_serialize_pk_info(key, b, opts)) != 0)
-			return ret;
-		break;
-#endif /* WITH_XMSS */
-	default:
-		return SSH_ERR_KEY_TYPE_UNKNOWN;
+		return 0;
 	}
-	return 0;
+	if ((impl = sshkey_impl_from_type(type)) == NULL)
+		return SSH_ERR_KEY_TYPE_UNKNOWN;
+
+	typename = sshkey_ssh_name_from_type_nid(type, key->ecdsa_nid);
+	return impl->funcs->serialize_public(key, b, typename, opts);
 }
 
 int

--- a/sshkey.c
+++ b/sshkey.c
@@ -427,6 +427,30 @@ sshkey_type_plain(int type)
 	}
 }
 
+/* Return the cert equivalent to a plain key type */
+static int
+sshkey_type_certified(int type)
+{
+	switch (type) {
+	case KEY_RSA:
+		return KEY_RSA_CERT;
+	case KEY_DSA:
+		return KEY_DSA_CERT;
+	case KEY_ECDSA:
+		return KEY_ECDSA_CERT;
+	case KEY_ECDSA_SK:
+		return KEY_ECDSA_SK_CERT;
+	case KEY_ED25519:
+		return KEY_ED25519_CERT;
+	case KEY_ED25519_SK:
+		return KEY_ED25519_SK_CERT;
+	case KEY_XMSS:
+		return KEY_XMSS_CERT;
+	default:
+		return -1;
+	}
+}
+
 #ifdef WITH_OPENSSL
 /* XXX: these are really begging for a table-driven approach */
 int
@@ -2065,35 +2089,8 @@ sshkey_to_certified(struct sshkey *k)
 {
 	int newtype;
 
-	switch (k->type) {
-#ifdef WITH_OPENSSL
-	case KEY_RSA:
-		newtype = KEY_RSA_CERT;
-		break;
-	case KEY_DSA:
-		newtype = KEY_DSA_CERT;
-		break;
-	case KEY_ECDSA:
-		newtype = KEY_ECDSA_CERT;
-		break;
-	case KEY_ECDSA_SK:
-		newtype = KEY_ECDSA_SK_CERT;
-		break;
-#endif /* WITH_OPENSSL */
-	case KEY_ED25519_SK:
-		newtype = KEY_ED25519_SK_CERT;
-		break;
-	case KEY_ED25519:
-		newtype = KEY_ED25519_CERT;
-		break;
-#ifdef WITH_XMSS
-	case KEY_XMSS:
-		newtype = KEY_XMSS_CERT;
-		break;
-#endif /* WITH_XMSS */
-	default:
+	if ((newtype = sshkey_type_certified(k->type)) == -1)
 		return SSH_ERR_INVALID_ARGUMENT;
-	}
 	if ((k->cert = cert_new()) == NULL)
 		return SSH_ERR_ALLOC_FAIL;
 	k->type = newtype;
@@ -2118,15 +2115,13 @@ sshkey_certify_custom(struct sshkey *k, struct sshkey *ca, const char *alg,
     const char *sk_provider, const char *sk_pin,
     sshkey_certify_signer *signer, void *signer_ctx)
 {
+	const struct sshkey_impl *impl;
 	struct sshbuf *principals = NULL;
 	u_char *ca_blob = NULL, *sig_blob = NULL, nonce[32];
 	size_t i, ca_len, sig_len;
 	int ret = SSH_ERR_INTERNAL_ERROR;
 	struct sshbuf *cert = NULL;
 	char *sigtype = NULL;
-#ifdef WITH_OPENSSL
-	const BIGNUM *rsa_n, *rsa_e, *dsa_p, *dsa_q, *dsa_g, *dsa_pub_key;
-#endif /* WITH_OPENSSL */
 
 	if (k == NULL || k->cert == NULL ||
 	    k->cert->certblob == NULL || ca == NULL)
@@ -2135,6 +2130,8 @@ sshkey_certify_custom(struct sshkey *k, struct sshkey *ca, const char *alg,
 		return SSH_ERR_KEY_TYPE_UNKNOWN;
 	if (!sshkey_type_is_valid_ca(ca->type))
 		return SSH_ERR_KEY_CERT_INVALID_SIGN_KEY;
+	if ((impl = sshkey_impl_from_key(k)) == NULL)
+		return SSH_ERR_INTERNAL_ERROR;
 
 	/*
 	 * If no alg specified as argument but a signature_type was set,
@@ -2166,67 +2163,12 @@ sshkey_certify_custom(struct sshkey *k, struct sshkey *ca, const char *alg,
 	if ((ret = sshbuf_put_string(cert, nonce, sizeof(nonce))) != 0)
 		goto out;
 
-	/* XXX this substantially duplicates to_blob(); refactor */
-	switch (k->type) {
-#ifdef WITH_OPENSSL
-	case KEY_DSA_CERT:
-		DSA_get0_pqg(k->dsa, &dsa_p, &dsa_q, &dsa_g);
-		DSA_get0_key(k->dsa, &dsa_pub_key, NULL);
-		if ((ret = sshbuf_put_bignum2(cert, dsa_p)) != 0 ||
-		    (ret = sshbuf_put_bignum2(cert, dsa_q)) != 0 ||
-		    (ret = sshbuf_put_bignum2(cert, dsa_g)) != 0 ||
-		    (ret = sshbuf_put_bignum2(cert, dsa_pub_key)) != 0)
-			goto out;
-		break;
-	case KEY_ECDSA_CERT:
-	case KEY_ECDSA_SK_CERT:
-		if ((ret = sshbuf_put_cstring(cert,
-		    sshkey_curve_nid_to_name(k->ecdsa_nid))) != 0 ||
-		    (ret = sshbuf_put_ec(cert,
-		    EC_KEY_get0_public_key(k->ecdsa),
-		    EC_KEY_get0_group(k->ecdsa))) != 0)
-			goto out;
-		if (k->type == KEY_ECDSA_SK_CERT) {
-			if ((ret = sshbuf_put_cstring(cert,
-			    k->sk_application)) != 0)
-				goto out;
-		}
-		break;
-	case KEY_RSA_CERT:
-		RSA_get0_key(k->rsa, &rsa_n, &rsa_e, NULL);
-		if ((ret = sshbuf_put_bignum2(cert, rsa_e)) != 0 ||
-		    (ret = sshbuf_put_bignum2(cert, rsa_n)) != 0)
-			goto out;
-		break;
-#endif /* WITH_OPENSSL */
-	case KEY_ED25519_CERT:
-	case KEY_ED25519_SK_CERT:
-		if ((ret = sshbuf_put_string(cert,
-		    k->ed25519_pk, ED25519_PK_SZ)) != 0)
-			goto out;
-		if (k->type == KEY_ED25519_SK_CERT) {
-			if ((ret = sshbuf_put_cstring(cert,
-			    k->sk_application)) != 0)
-				goto out;
-		}
-		break;
-#ifdef WITH_XMSS
-	case KEY_XMSS_CERT:
-		if (k->xmss_name == NULL) {
-			ret = SSH_ERR_INVALID_ARGUMENT;
-			goto out;
-		}
-		if ((ret = sshbuf_put_cstring(cert, k->xmss_name)) ||
-		    (ret = sshbuf_put_string(cert,
-		    k->xmss_pk, sshkey_xmss_pklen(k))) != 0)
-			goto out;
-		break;
-#endif /* WITH_XMSS */
-	default:
-		ret = SSH_ERR_INVALID_ARGUMENT;
+	/* Public key next */
+	if ((ret = impl->funcs->serialize_public(k, cert,
+	    SSHKEY_SERIALIZE_DEFAULT)) != 0)
 		goto out;
-	}
 
+	/* Then remaining cert fields */
 	if ((ret = sshbuf_put_u64(cert, k->cert->serial)) != 0 ||
 	    (ret = sshbuf_put_u32(cert, k->cert->type)) != 0 ||
 	    (ret = sshbuf_put_cstring(cert, k->cert->key_id)) != 0)

--- a/sshkey.c
+++ b/sshkey.c
@@ -2364,6 +2364,21 @@ sshkey_format_cert_validity(const struct sshkey_cert *cert, char *s, size_t l)
 	return strlcpy(s, ret, l);
 }
 
+/* Common serialization for FIDO private keys */
+int
+sshkey_serialize_private_sk(const struct sshkey *key, struct sshbuf *b)
+{
+	int r;
+
+	if ((r = sshbuf_put_cstring(b, key->sk_application)) != 0 ||
+	    (r = sshbuf_put_u8(b, key->sk_flags)) != 0 ||
+	    (r = sshbuf_put_stringb(b, key->sk_key_handle)) != 0 ||
+	    (r = sshbuf_put_stringb(b, key->sk_reserved)) != 0)
+		return r;
+
+	return 0;
+}
+
 int
 sshkey_private_serialize_opt(struct sshkey *key, struct sshbuf *buf,
     enum sshkey_serialize_rep opts)
@@ -2371,183 +2386,28 @@ sshkey_private_serialize_opt(struct sshkey *key, struct sshbuf *buf,
 	int r = SSH_ERR_INTERNAL_ERROR;
 	int was_shielded = sshkey_is_shielded(key);
 	struct sshbuf *b = NULL;
-#ifdef WITH_OPENSSL
-	const BIGNUM *rsa_n, *rsa_e, *rsa_d, *rsa_iqmp, *rsa_p, *rsa_q;
-	const BIGNUM *dsa_p, *dsa_q, *dsa_g, *dsa_pub_key, *dsa_priv_key;
-#endif /* WITH_OPENSSL */
+	const struct sshkey_impl *impl;
 
+	if ((impl = sshkey_impl_from_key(key)) == NULL)
+		return SSH_ERR_INTERNAL_ERROR;
 	if ((r = sshkey_unshield_private(key)) != 0)
 		return r;
 	if ((b = sshbuf_new()) == NULL)
 		return SSH_ERR_ALLOC_FAIL;
 	if ((r = sshbuf_put_cstring(b, sshkey_ssh_name(key))) != 0)
 		goto out;
-	switch (key->type) {
-#ifdef WITH_OPENSSL
-	case KEY_RSA:
-		RSA_get0_key(key->rsa, &rsa_n, &rsa_e, &rsa_d);
-		RSA_get0_factors(key->rsa, &rsa_p, &rsa_q);
-		RSA_get0_crt_params(key->rsa, NULL, NULL, &rsa_iqmp);
-		if ((r = sshbuf_put_bignum2(b, rsa_n)) != 0 ||
-		    (r = sshbuf_put_bignum2(b, rsa_e)) != 0 ||
-		    (r = sshbuf_put_bignum2(b, rsa_d)) != 0 ||
-		    (r = sshbuf_put_bignum2(b, rsa_iqmp)) != 0 ||
-		    (r = sshbuf_put_bignum2(b, rsa_p)) != 0 ||
-		    (r = sshbuf_put_bignum2(b, rsa_q)) != 0)
-			goto out;
-		break;
-	case KEY_RSA_CERT:
-		if (key->cert == NULL || sshbuf_len(key->cert->certblob) == 0) {
+	if (sshkey_is_cert(key)) {
+		if (key->cert == NULL ||
+		    sshbuf_len(key->cert->certblob) == 0) {
 			r = SSH_ERR_INVALID_ARGUMENT;
 			goto out;
 		}
-		RSA_get0_key(key->rsa, NULL, NULL, &rsa_d);
-		RSA_get0_factors(key->rsa, &rsa_p, &rsa_q);
-		RSA_get0_crt_params(key->rsa, NULL, NULL, &rsa_iqmp);
-		if ((r = sshbuf_put_stringb(b, key->cert->certblob)) != 0 ||
-		    (r = sshbuf_put_bignum2(b, rsa_d)) != 0 ||
-		    (r = sshbuf_put_bignum2(b, rsa_iqmp)) != 0 ||
-		    (r = sshbuf_put_bignum2(b, rsa_p)) != 0 ||
-		    (r = sshbuf_put_bignum2(b, rsa_q)) != 0)
+		if ((r = sshbuf_put_stringb(b, key->cert->certblob)) != 0)
 			goto out;
-		break;
-	case KEY_DSA:
-		DSA_get0_pqg(key->dsa, &dsa_p, &dsa_q, &dsa_g);
-		DSA_get0_key(key->dsa, &dsa_pub_key, &dsa_priv_key);
-		if ((r = sshbuf_put_bignum2(b, dsa_p)) != 0 ||
-		    (r = sshbuf_put_bignum2(b, dsa_q)) != 0 ||
-		    (r = sshbuf_put_bignum2(b, dsa_g)) != 0 ||
-		    (r = sshbuf_put_bignum2(b, dsa_pub_key)) != 0 ||
-		    (r = sshbuf_put_bignum2(b, dsa_priv_key)) != 0)
-			goto out;
-		break;
-	case KEY_DSA_CERT:
-		if (key->cert == NULL || sshbuf_len(key->cert->certblob) == 0) {
-			r = SSH_ERR_INVALID_ARGUMENT;
-			goto out;
-		}
-		DSA_get0_key(key->dsa, NULL, &dsa_priv_key);
-		if ((r = sshbuf_put_stringb(b, key->cert->certblob)) != 0 ||
-		    (r = sshbuf_put_bignum2(b, dsa_priv_key)) != 0)
-			goto out;
-		break;
-	case KEY_ECDSA:
-		if ((r = sshbuf_put_cstring(b,
-		    sshkey_curve_nid_to_name(key->ecdsa_nid))) != 0 ||
-		    (r = sshbuf_put_eckey(b, key->ecdsa)) != 0 ||
-		    (r = sshbuf_put_bignum2(b,
-		    EC_KEY_get0_private_key(key->ecdsa))) != 0)
-			goto out;
-		break;
-	case KEY_ECDSA_CERT:
-		if (key->cert == NULL || sshbuf_len(key->cert->certblob) == 0) {
-			r = SSH_ERR_INVALID_ARGUMENT;
-			goto out;
-		}
-		if ((r = sshbuf_put_stringb(b, key->cert->certblob)) != 0 ||
-		    (r = sshbuf_put_bignum2(b,
-		    EC_KEY_get0_private_key(key->ecdsa))) != 0)
-			goto out;
-		break;
-	case KEY_ECDSA_SK:
-		if ((r = sshbuf_put_cstring(b,
-		    sshkey_curve_nid_to_name(key->ecdsa_nid))) != 0 ||
-		    (r = sshbuf_put_eckey(b, key->ecdsa)) != 0 ||
-		    (r = sshbuf_put_cstring(b, key->sk_application)) != 0 ||
-		    (r = sshbuf_put_u8(b, key->sk_flags)) != 0 ||
-		    (r = sshbuf_put_stringb(b, key->sk_key_handle)) != 0 ||
-		    (r = sshbuf_put_stringb(b, key->sk_reserved)) != 0)
-			goto out;
-		break;
-	case KEY_ECDSA_SK_CERT:
-		if (key->cert == NULL || sshbuf_len(key->cert->certblob) == 0) {
-			r = SSH_ERR_INVALID_ARGUMENT;
-			goto out;
-		}
-		if ((r = sshbuf_put_stringb(b, key->cert->certblob)) != 0 ||
-		    (r = sshbuf_put_cstring(b, key->sk_application)) != 0 ||
-		    (r = sshbuf_put_u8(b, key->sk_flags)) != 0 ||
-		    (r = sshbuf_put_stringb(b, key->sk_key_handle)) != 0 ||
-		    (r = sshbuf_put_stringb(b, key->sk_reserved)) != 0)
-			goto out;
-		break;
-#endif /* WITH_OPENSSL */
-	case KEY_ED25519:
-		if ((r = sshbuf_put_string(b, key->ed25519_pk,
-		    ED25519_PK_SZ)) != 0 ||
-		    (r = sshbuf_put_string(b, key->ed25519_sk,
-		    ED25519_SK_SZ)) != 0)
-			goto out;
-		break;
-	case KEY_ED25519_CERT:
-		if (key->cert == NULL || sshbuf_len(key->cert->certblob) == 0) {
-			r = SSH_ERR_INVALID_ARGUMENT;
-			goto out;
-		}
-		if ((r = sshbuf_put_stringb(b, key->cert->certblob)) != 0 ||
-		    (r = sshbuf_put_string(b, key->ed25519_pk,
-		    ED25519_PK_SZ)) != 0 ||
-		    (r = sshbuf_put_string(b, key->ed25519_sk,
-		    ED25519_SK_SZ)) != 0)
-			goto out;
-		break;
-	case KEY_ED25519_SK:
-		if ((r = sshbuf_put_string(b, key->ed25519_pk,
-		    ED25519_PK_SZ)) != 0 ||
-		    (r = sshbuf_put_cstring(b, key->sk_application)) != 0 ||
-		    (r = sshbuf_put_u8(b, key->sk_flags)) != 0 ||
-		    (r = sshbuf_put_stringb(b, key->sk_key_handle)) != 0 ||
-		    (r = sshbuf_put_stringb(b, key->sk_reserved)) != 0)
-			goto out;
-		break;
-	case KEY_ED25519_SK_CERT:
-		if (key->cert == NULL || sshbuf_len(key->cert->certblob) == 0) {
-			r = SSH_ERR_INVALID_ARGUMENT;
-			goto out;
-		}
-		if ((r = sshbuf_put_stringb(b, key->cert->certblob)) != 0 ||
-		    (r = sshbuf_put_string(b, key->ed25519_pk,
-		    ED25519_PK_SZ)) != 0 ||
-		    (r = sshbuf_put_cstring(b, key->sk_application)) != 0 ||
-		    (r = sshbuf_put_u8(b, key->sk_flags)) != 0 ||
-		    (r = sshbuf_put_stringb(b, key->sk_key_handle)) != 0 ||
-		    (r = sshbuf_put_stringb(b, key->sk_reserved)) != 0)
-			goto out;
-		break;
-#ifdef WITH_XMSS
-	case KEY_XMSS:
-		if (key->xmss_name == NULL) {
-			r = SSH_ERR_INVALID_ARGUMENT;
-			goto out;
-		}
-		if ((r = sshbuf_put_cstring(b, key->xmss_name)) != 0 ||
-		    (r = sshbuf_put_string(b, key->xmss_pk,
-		    sshkey_xmss_pklen(key))) != 0 ||
-		    (r = sshbuf_put_string(b, key->xmss_sk,
-		    sshkey_xmss_sklen(key))) != 0 ||
-		    (r = sshkey_xmss_serialize_state_opt(key, b, opts)) != 0)
-			goto out;
-		break;
-	case KEY_XMSS_CERT:
-		if (key->cert == NULL || sshbuf_len(key->cert->certblob) == 0 ||
-		    key->xmss_name == NULL) {
-			r = SSH_ERR_INVALID_ARGUMENT;
-			goto out;
-		}
-		if ((r = sshbuf_put_stringb(b, key->cert->certblob)) != 0 ||
-		    (r = sshbuf_put_cstring(b, key->xmss_name)) != 0 ||
-		    (r = sshbuf_put_string(b, key->xmss_pk,
-		    sshkey_xmss_pklen(key))) != 0 ||
-		    (r = sshbuf_put_string(b, key->xmss_sk,
-		    sshkey_xmss_sklen(key))) != 0 ||
-		    (r = sshkey_xmss_serialize_state_opt(key, b, opts)) != 0)
-			goto out;
-		break;
-#endif /* WITH_XMSS */
-	default:
-		r = SSH_ERR_INVALID_ARGUMENT;
-		goto out;
 	}
+	if ((r = impl->funcs->serialize_private(key, b, opts)) != 0)
+		goto out;
+
 	/*
 	 * success (but we still need to append the output to buf after
 	 * possibly re-shielding the private key)

--- a/sshkey.c
+++ b/sshkey.c
@@ -1265,65 +1265,6 @@ sshkey_cert_type(const struct sshkey *k)
 }
 
 #ifdef WITH_OPENSSL
-static int
-rsa_generate_private_key(u_int bits, RSA **rsap)
-{
-	RSA *private = NULL;
-	BIGNUM *f4 = NULL;
-	int ret = SSH_ERR_INTERNAL_ERROR;
-
-	if (rsap == NULL)
-		return SSH_ERR_INVALID_ARGUMENT;
-	if (bits < SSH_RSA_MINIMUM_MODULUS_SIZE ||
-	    bits > SSHBUF_MAX_BIGNUM * 8)
-		return SSH_ERR_KEY_LENGTH;
-	*rsap = NULL;
-	if ((private = RSA_new()) == NULL || (f4 = BN_new()) == NULL) {
-		ret = SSH_ERR_ALLOC_FAIL;
-		goto out;
-	}
-	if (!BN_set_word(f4, RSA_F4) ||
-	    !RSA_generate_key_ex(private, bits, f4, NULL)) {
-		ret = SSH_ERR_LIBCRYPTO_ERROR;
-		goto out;
-	}
-	*rsap = private;
-	private = NULL;
-	ret = 0;
- out:
-	RSA_free(private);
-	BN_free(f4);
-	return ret;
-}
-
-static int
-dsa_generate_private_key(u_int bits, DSA **dsap)
-{
-	DSA *private;
-	int ret = SSH_ERR_INTERNAL_ERROR;
-
-	if (dsap == NULL)
-		return SSH_ERR_INVALID_ARGUMENT;
-	if (bits != 1024)
-		return SSH_ERR_KEY_LENGTH;
-	if ((private = DSA_new()) == NULL) {
-		ret = SSH_ERR_ALLOC_FAIL;
-		goto out;
-	}
-	*dsap = NULL;
-	if (!DSA_generate_parameters_ex(private, bits, NULL, 0, NULL,
-	    NULL, NULL) || !DSA_generate_key(private)) {
-		ret = SSH_ERR_LIBCRYPTO_ERROR;
-		goto out;
-	}
-	*dsap = private;
-	private = NULL;
-	ret = 0;
- out:
-	DSA_free(private);
-	return ret;
-}
-
 int
 sshkey_ecdsa_key_to_nid(EC_KEY *k)
 {
@@ -1366,33 +1307,6 @@ sshkey_ecdsa_key_to_nid(EC_KEY *k)
 	return nids[i];
 }
 
-static int
-ecdsa_generate_private_key(u_int bits, int *nid, EC_KEY **ecdsap)
-{
-	EC_KEY *private;
-	int ret = SSH_ERR_INTERNAL_ERROR;
-
-	if (nid == NULL || ecdsap == NULL)
-		return SSH_ERR_INVALID_ARGUMENT;
-	if ((*nid = sshkey_ecdsa_bits_to_nid(bits)) == -1)
-		return SSH_ERR_KEY_LENGTH;
-	*ecdsap = NULL;
-	if ((private = EC_KEY_new_by_curve_name(*nid)) == NULL) {
-		ret = SSH_ERR_ALLOC_FAIL;
-		goto out;
-	}
-	if (EC_KEY_generate_key(private) != 1) {
-		ret = SSH_ERR_LIBCRYPTO_ERROR;
-		goto out;
-	}
-	EC_KEY_set_asn1_flag(private, OPENSSL_EC_NAMED_CURVE);
-	*ecdsap = private;
-	private = NULL;
-	ret = 0;
- out:
-	EC_KEY_free(private);
-	return ret;
-}
 #endif /* WITH_OPENSSL */
 
 int
@@ -1400,48 +1314,25 @@ sshkey_generate(int type, u_int bits, struct sshkey **keyp)
 {
 	struct sshkey *k;
 	int ret = SSH_ERR_INTERNAL_ERROR;
+	const struct sshkey_impl *impl;
 
-	if (keyp == NULL)
+	if (keyp == NULL || sshkey_type_is_cert(type))
 		return SSH_ERR_INVALID_ARGUMENT;
 	*keyp = NULL;
+	if ((impl = sshkey_impl_from_type(type)) == NULL)
+		return SSH_ERR_KEY_TYPE_UNKNOWN;
+	if (impl->funcs->generate == NULL)
+		return SSH_ERR_FEATURE_UNSUPPORTED;
 	if ((k = sshkey_new(KEY_UNSPEC)) == NULL)
 		return SSH_ERR_ALLOC_FAIL;
-	switch (type) {
-	case KEY_ED25519:
-		if ((k->ed25519_pk = malloc(ED25519_PK_SZ)) == NULL ||
-		    (k->ed25519_sk = malloc(ED25519_SK_SZ)) == NULL) {
-			ret = SSH_ERR_ALLOC_FAIL;
-			break;
-		}
-		crypto_sign_ed25519_keypair(k->ed25519_pk, k->ed25519_sk);
-		ret = 0;
-		break;
-#ifdef WITH_XMSS
-	case KEY_XMSS:
-		ret = sshkey_xmss_generate_private_key(k, bits);
-		break;
-#endif /* WITH_XMSS */
-#ifdef WITH_OPENSSL
-	case KEY_DSA:
-		ret = dsa_generate_private_key(bits, &k->dsa);
-		break;
-	case KEY_ECDSA:
-		ret = ecdsa_generate_private_key(bits, &k->ecdsa_nid,
-		    &k->ecdsa);
-		break;
-	case KEY_RSA:
-		ret = rsa_generate_private_key(bits, &k->rsa);
-		break;
-#endif /* WITH_OPENSSL */
-	default:
-		ret = SSH_ERR_INVALID_ARGUMENT;
-	}
-	if (ret == 0) {
-		k->type = type;
-		*keyp = k;
-	} else
+	k->type = type;
+	if ((ret = impl->funcs->generate(k, bits)) != 0) {
 		sshkey_free(k);
-	return ret;
+		return ret;
+	}
+	/* success */
+	*keyp = k;
+	return 0;
 }
 
 int

--- a/sshkey.c
+++ b/sshkey.c
@@ -171,12 +171,20 @@ sshkey_impl_from_type_nid(int type, int nid)
 	return NULL;
 }
 
+static const struct sshkey_impl *
+sshkey_impl_from_key(const struct sshkey *k)
+{
+	if (k == NULL)
+		return NULL;
+	return sshkey_impl_from_type_nid(k->type, k->ecdsa_nid);
+}
+
 const char *
 sshkey_type(const struct sshkey *k)
 {
 	const struct sshkey_impl *impl;
 
-	if ((impl = sshkey_impl_from_type(k->type)) == NULL)
+	if ((impl = sshkey_impl_from_key(k)) == NULL)
 		return "unknown";
 	return impl->shortname;
 }
@@ -355,7 +363,7 @@ sshkey_size(const struct sshkey *k)
 {
 	const struct sshkey_impl *impl;
 
-	if ((impl = sshkey_impl_from_type_nid(k->type, k->ecdsa_nid)) == NULL)
+	if ((impl = sshkey_impl_from_key(k)) == NULL)
 		return 0;
 	if (impl->funcs->size != NULL)
 		return impl->funcs->size(k);
@@ -578,8 +586,8 @@ sshkey_sk_cleanup(struct sshkey *k)
 	k->sk_key_handle = k->sk_reserved = NULL;
 }
 
-void
-sshkey_free(struct sshkey *k)
+static void
+sshkey_free_contents(struct sshkey *k)
 {
 	const struct sshkey_impl *impl;
 
@@ -592,6 +600,12 @@ sshkey_free(struct sshkey *k)
 		cert_free(k->cert);
 	freezero(k->shielded_private, k->shielded_len);
 	freezero(k->shield_prekey, k->shield_prekey_len);
+}
+
+void
+sshkey_free(struct sshkey *k)
+{
+	sshkey_free_contents(k);
 	freezero(k, sizeof(*k));
 }
 
@@ -1105,29 +1119,8 @@ sshkey_read(struct sshkey *ret, char **cpp)
 
 	if (ret == NULL)
 		return SSH_ERR_INVALID_ARGUMENT;
-
-	switch (ret->type) {
-	case KEY_UNSPEC:
-	case KEY_RSA:
-	case KEY_DSA:
-	case KEY_ECDSA:
-	case KEY_ECDSA_SK:
-	case KEY_ED25519:
-	case KEY_ED25519_SK:
-	case KEY_DSA_CERT:
-	case KEY_ECDSA_CERT:
-	case KEY_ECDSA_SK_CERT:
-	case KEY_RSA_CERT:
-	case KEY_ED25519_CERT:
-	case KEY_ED25519_SK_CERT:
-#ifdef WITH_XMSS
-	case KEY_XMSS:
-	case KEY_XMSS_CERT:
-#endif /* WITH_XMSS */
-		break; /* ok */
-	default:
+	if (ret->type != KEY_UNSPEC && sshkey_impl_from_type(ret->type) == NULL)
 		return SSH_ERR_INVALID_ARGUMENT;
-	}
 
 	/* Decode type */
 	cp = *cpp;
@@ -1180,98 +1173,9 @@ sshkey_read(struct sshkey *ret, char **cpp)
 	}
 
 	/* Fill in ret from parsed key */
-	ret->type = type;
-	if (sshkey_is_cert(ret)) {
-		if (!sshkey_is_cert(k)) {
-			sshkey_free(k);
-			return SSH_ERR_EXPECTED_CERT;
-		}
-		if (ret->cert != NULL)
-			cert_free(ret->cert);
-		ret->cert = k->cert;
-		k->cert = NULL;
-	}
-	switch (sshkey_type_plain(ret->type)) {
-#ifdef WITH_OPENSSL
-	case KEY_RSA:
-		RSA_free(ret->rsa);
-		ret->rsa = k->rsa;
-		k->rsa = NULL;
-#ifdef DEBUG_PK
-		RSA_print_fp(stderr, ret->rsa, 8);
-#endif
-		break;
-	case KEY_DSA:
-		DSA_free(ret->dsa);
-		ret->dsa = k->dsa;
-		k->dsa = NULL;
-#ifdef DEBUG_PK
-		DSA_print_fp(stderr, ret->dsa, 8);
-#endif
-		break;
-	case KEY_ECDSA:
-		EC_KEY_free(ret->ecdsa);
-		ret->ecdsa = k->ecdsa;
-		ret->ecdsa_nid = k->ecdsa_nid;
-		k->ecdsa = NULL;
-		k->ecdsa_nid = -1;
-#ifdef DEBUG_PK
-		sshkey_dump_ec_key(ret->ecdsa);
-#endif
-		break;
-	case KEY_ECDSA_SK:
-		EC_KEY_free(ret->ecdsa);
-		ret->ecdsa = k->ecdsa;
-		ret->ecdsa_nid = k->ecdsa_nid;
-		ret->sk_application = k->sk_application;
-		k->ecdsa = NULL;
-		k->ecdsa_nid = -1;
-		k->sk_application = NULL;
-#ifdef DEBUG_PK
-		sshkey_dump_ec_key(ret->ecdsa);
-		fprintf(stderr, "App: %s\n", ret->sk_application);
-#endif
-		break;
-#endif /* WITH_OPENSSL */
-	case KEY_ED25519:
-		freezero(ret->ed25519_pk, ED25519_PK_SZ);
-		ret->ed25519_pk = k->ed25519_pk;
-		k->ed25519_pk = NULL;
-#ifdef DEBUG_PK
-		/* XXX */
-#endif
-		break;
-	case KEY_ED25519_SK:
-		freezero(ret->ed25519_pk, ED25519_PK_SZ);
-		ret->ed25519_pk = k->ed25519_pk;
-		ret->sk_application = k->sk_application;
-		k->ed25519_pk = NULL;
-		k->sk_application = NULL;
-		break;
-#ifdef WITH_XMSS
-	case KEY_XMSS:
-		free(ret->xmss_pk);
-		ret->xmss_pk = k->xmss_pk;
-		k->xmss_pk = NULL;
-		free(ret->xmss_state);
-		ret->xmss_state = k->xmss_state;
-		k->xmss_state = NULL;
-		free(ret->xmss_name);
-		ret->xmss_name = k->xmss_name;
-		k->xmss_name = NULL;
-		free(ret->xmss_filename);
-		ret->xmss_filename = k->xmss_filename;
-		k->xmss_filename = NULL;
-#ifdef DEBUG_PK
-		/* XXX */
-#endif
-		break;
-#endif /* WITH_XMSS */
-	default:
-		sshkey_free(k);
-		return SSH_ERR_INTERNAL_ERROR;
-	}
-	sshkey_free(k);
+	sshkey_free_contents(ret);
+	*ret = *k;
+	freezero(k, sizeof(*k));
 
 	/* success */
 	*cpp = cp;

--- a/sshkey.c
+++ b/sshkey.c
@@ -704,7 +704,9 @@ to_blob_buf(const struct sshkey *key, struct sshbuf *b, int force_plain,
 		return SSH_ERR_KEY_TYPE_UNKNOWN;
 
 	typename = sshkey_ssh_name_from_type_nid(type, key->ecdsa_nid);
-	return impl->funcs->serialize_public(key, b, typename, opts);
+	if ((ret = sshbuf_put_cstring(b, typename)) != 0)
+		return ret;
+	return impl->funcs->serialize_public(key, b, opts);
 }
 
 int
@@ -1800,21 +1802,11 @@ cert_parse(struct sshbuf *b, struct sshkey *key, struct sshbuf *certbuf)
 }
 
 int
-sshkey_check_rsa_length(const struct sshkey *k, int min_size)
+sshkey_deserialize_sk(struct sshbuf *b, struct sshkey *key)
 {
-#ifdef WITH_OPENSSL
-	const BIGNUM *rsa_n;
-	int nbits;
-
-	if (k == NULL || k->rsa == NULL ||
-	    (k->type != KEY_RSA && k->type != KEY_RSA_CERT))
-		return 0;
-	RSA_get0_key(k->rsa, &rsa_n, NULL, NULL);
-	nbits = BN_num_bits(rsa_n);
-	if (nbits < SSH_RSA_MINIMUM_MODULUS_SIZE ||
-	    (min_size > 0 && nbits < min_size))
-		return SSH_ERR_KEY_LENGTH;
-#endif /* WITH_OPENSSL */
+	/* Parse additional security-key application string */
+	if (sshbuf_get_cstring(b, &key->sk_application, NULL) != 0)
+		return SSH_ERR_INVALID_FORMAT;
 	return 0;
 }
 
@@ -1823,16 +1815,10 @@ sshkey_from_blob_internal(struct sshbuf *b, struct sshkey **keyp,
     int allow_cert)
 {
 	int type, ret = SSH_ERR_INTERNAL_ERROR;
-	char *ktype = NULL, *curve = NULL, *xmss_name = NULL;
+	char *ktype = NULL;
 	struct sshkey *key = NULL;
-	size_t len;
-	u_char *pk = NULL;
 	struct sshbuf *copy;
-#ifdef WITH_OPENSSL
-	EC_POINT *q = NULL;
-	BIGNUM *rsa_n = NULL, *rsa_e = NULL;
-	BIGNUM *dsa_p = NULL, *dsa_q = NULL, *dsa_g = NULL, *dsa_pub_key = NULL;
-#endif /* WITH_OPENSSL */
+	const struct sshkey_impl *impl;
 
 #ifdef DEBUG_PK /* XXX */
 	sshbuf_dump(b, stderr);
@@ -1853,201 +1839,23 @@ sshkey_from_blob_internal(struct sshbuf *b, struct sshkey **keyp,
 		ret = SSH_ERR_KEY_CERT_INVALID_SIGN_KEY;
 		goto out;
 	}
-	switch (type) {
-#ifdef WITH_OPENSSL
-	case KEY_RSA_CERT:
-		/* Skip nonce */
-		if (sshbuf_get_string_direct(b, NULL, NULL) != 0) {
-			ret = SSH_ERR_INVALID_FORMAT;
-			goto out;
-		}
-		/* FALLTHROUGH */
-	case KEY_RSA:
-		if ((key = sshkey_new(type)) == NULL) {
-			ret = SSH_ERR_ALLOC_FAIL;
-			goto out;
-		}
-		if (sshbuf_get_bignum2(b, &rsa_e) != 0 ||
-		    sshbuf_get_bignum2(b, &rsa_n) != 0) {
-			ret = SSH_ERR_INVALID_FORMAT;
-			goto out;
-		}
-		if (!RSA_set0_key(key->rsa, rsa_n, rsa_e, NULL)) {
-			ret = SSH_ERR_LIBCRYPTO_ERROR;
-			goto out;
-		}
-		rsa_n = rsa_e = NULL; /* transferred */
-		if ((ret = sshkey_check_rsa_length(key, 0)) != 0)
-			goto out;
-#ifdef DEBUG_PK
-		RSA_print_fp(stderr, key->rsa, 8);
-#endif
-		break;
-	case KEY_DSA_CERT:
-		/* Skip nonce */
-		if (sshbuf_get_string_direct(b, NULL, NULL) != 0) {
-			ret = SSH_ERR_INVALID_FORMAT;
-			goto out;
-		}
-		/* FALLTHROUGH */
-	case KEY_DSA:
-		if ((key = sshkey_new(type)) == NULL) {
-			ret = SSH_ERR_ALLOC_FAIL;
-			goto out;
-		}
-		if (sshbuf_get_bignum2(b, &dsa_p) != 0 ||
-		    sshbuf_get_bignum2(b, &dsa_q) != 0 ||
-		    sshbuf_get_bignum2(b, &dsa_g) != 0 ||
-		    sshbuf_get_bignum2(b, &dsa_pub_key) != 0) {
-			ret = SSH_ERR_INVALID_FORMAT;
-			goto out;
-		}
-		if (!DSA_set0_pqg(key->dsa, dsa_p, dsa_q, dsa_g)) {
-			ret = SSH_ERR_LIBCRYPTO_ERROR;
-			goto out;
-		}
-		dsa_p = dsa_q = dsa_g = NULL; /* transferred */
-		if (!DSA_set0_key(key->dsa, dsa_pub_key, NULL)) {
-			ret = SSH_ERR_LIBCRYPTO_ERROR;
-			goto out;
-		}
-		dsa_pub_key = NULL; /* transferred */
-#ifdef DEBUG_PK
-		DSA_print_fp(stderr, key->dsa, 8);
-#endif
-		break;
-	case KEY_ECDSA_CERT:
-	case KEY_ECDSA_SK_CERT:
-		/* Skip nonce */
-		if (sshbuf_get_string_direct(b, NULL, NULL) != 0) {
-			ret = SSH_ERR_INVALID_FORMAT;
-			goto out;
-		}
-		/* FALLTHROUGH */
-	case KEY_ECDSA:
-	case KEY_ECDSA_SK:
-		if ((key = sshkey_new(type)) == NULL) {
-			ret = SSH_ERR_ALLOC_FAIL;
-			goto out;
-		}
-		key->ecdsa_nid = sshkey_ecdsa_nid_from_name(ktype);
-		if (sshbuf_get_cstring(b, &curve, NULL) != 0) {
-			ret = SSH_ERR_INVALID_FORMAT;
-			goto out;
-		}
-		if (key->ecdsa_nid != sshkey_curve_name_to_nid(curve)) {
-			ret = SSH_ERR_EC_CURVE_MISMATCH;
-			goto out;
-		}
-		EC_KEY_free(key->ecdsa);
-		if ((key->ecdsa = EC_KEY_new_by_curve_name(key->ecdsa_nid))
-		    == NULL) {
-			ret = SSH_ERR_EC_CURVE_INVALID;
-			goto out;
-		}
-		if ((q = EC_POINT_new(EC_KEY_get0_group(key->ecdsa))) == NULL) {
-			ret = SSH_ERR_ALLOC_FAIL;
-			goto out;
-		}
-		if (sshbuf_get_ec(b, q, EC_KEY_get0_group(key->ecdsa)) != 0) {
-			ret = SSH_ERR_INVALID_FORMAT;
-			goto out;
-		}
-		if (sshkey_ec_validate_public(EC_KEY_get0_group(key->ecdsa),
-		    q) != 0) {
-			ret = SSH_ERR_KEY_INVALID_EC_VALUE;
-			goto out;
-		}
-		if (EC_KEY_set_public_key(key->ecdsa, q) != 1) {
-			/* XXX assume it is a allocation error */
-			ret = SSH_ERR_ALLOC_FAIL;
-			goto out;
-		}
-#ifdef DEBUG_PK
-		sshkey_dump_ec_point(EC_KEY_get0_group(key->ecdsa), q);
-#endif
-		if (type == KEY_ECDSA_SK || type == KEY_ECDSA_SK_CERT) {
-			/* Parse additional security-key application string */
-			if (sshbuf_get_cstring(b, &key->sk_application,
-			    NULL) != 0) {
-				ret = SSH_ERR_INVALID_FORMAT;
-				goto out;
-			}
-#ifdef DEBUG_PK
-			fprintf(stderr, "App: %s\n", key->sk_application);
-#endif
-		}
-		break;
-#endif /* WITH_OPENSSL */
-	case KEY_ED25519_CERT:
-	case KEY_ED25519_SK_CERT:
-		/* Skip nonce */
-		if (sshbuf_get_string_direct(b, NULL, NULL) != 0) {
-			ret = SSH_ERR_INVALID_FORMAT;
-			goto out;
-		}
-		/* FALLTHROUGH */
-	case KEY_ED25519:
-	case KEY_ED25519_SK:
-		if ((ret = sshbuf_get_string(b, &pk, &len)) != 0)
-			goto out;
-		if (len != ED25519_PK_SZ) {
-			ret = SSH_ERR_INVALID_FORMAT;
-			goto out;
-		}
-		if ((key = sshkey_new(type)) == NULL) {
-			ret = SSH_ERR_ALLOC_FAIL;
-			goto out;
-		}
-		if (type == KEY_ED25519_SK || type == KEY_ED25519_SK_CERT) {
-			/* Parse additional security-key application string */
-			if (sshbuf_get_cstring(b, &key->sk_application,
-			    NULL) != 0) {
-				ret = SSH_ERR_INVALID_FORMAT;
-				goto out;
-			}
-#ifdef DEBUG_PK
-			fprintf(stderr, "App: %s\n", key->sk_application);
-#endif
-		}
-		key->ed25519_pk = pk;
-		pk = NULL;
-		break;
-#ifdef WITH_XMSS
-	case KEY_XMSS_CERT:
-		/* Skip nonce */
-		if (sshbuf_get_string_direct(b, NULL, NULL) != 0) {
-			ret = SSH_ERR_INVALID_FORMAT;
-			goto out;
-		}
-		/* FALLTHROUGH */
-	case KEY_XMSS:
-		if ((ret = sshbuf_get_cstring(b, &xmss_name, NULL)) != 0)
-			goto out;
-		if ((key = sshkey_new(type)) == NULL) {
-			ret = SSH_ERR_ALLOC_FAIL;
-			goto out;
-		}
-		if ((ret = sshkey_xmss_init(key, xmss_name)) != 0)
-			goto out;
-		if ((ret = sshbuf_get_string(b, &pk, &len)) != 0)
-			goto out;
-		if (len == 0 || len != sshkey_xmss_pklen(key)) {
-			ret = SSH_ERR_INVALID_FORMAT;
-			goto out;
-		}
-		key->xmss_pk = pk;
-		pk = NULL;
-		if (type != KEY_XMSS_CERT &&
-		    (ret = sshkey_xmss_deserialize_pk_info(key, b)) != 0)
-			goto out;
-		break;
-#endif /* WITH_XMSS */
-	case KEY_UNSPEC:
-	default:
+	if ((impl = sshkey_impl_from_type(type)) == NULL) {
 		ret = SSH_ERR_KEY_TYPE_UNKNOWN;
 		goto out;
 	}
+	if ((key = sshkey_new(type)) == NULL) {
+		ret = SSH_ERR_ALLOC_FAIL;
+		goto out;
+	}
+	if (sshkey_type_is_cert(type)) {
+		/* Skip nonce that preceeds all certificates */
+		if (sshbuf_get_string_direct(b, NULL, NULL) != 0) {
+			ret = SSH_ERR_INVALID_FORMAT;
+			goto out;
+		}
+	}
+	if ((ret = impl->funcs->deserialize_public(ktype, b, key)) != 0)
+		goto out;
 
 	/* Parse certificate potion */
 	if (sshkey_is_cert(key) && (ret = cert_parse(b, key, copy)) != 0)
@@ -2065,19 +1873,7 @@ sshkey_from_blob_internal(struct sshbuf *b, struct sshkey **keyp,
  out:
 	sshbuf_free(copy);
 	sshkey_free(key);
-	free(xmss_name);
 	free(ktype);
-	free(curve);
-	free(pk);
-#ifdef WITH_OPENSSL
-	EC_POINT_free(q);
-	BN_clear_free(rsa_n);
-	BN_clear_free(rsa_e);
-	BN_clear_free(dsa_p);
-	BN_clear_free(dsa_q);
-	BN_clear_free(dsa_g);
-	BN_clear_free(dsa_pub_key);
-#endif /* WITH_OPENSSL */
 	return ret;
 }
 

--- a/sshkey.c
+++ b/sshkey.c
@@ -2430,24 +2430,33 @@ sshkey_private_serialize(struct sshkey *key, struct sshbuf *b)
 	    SSHKEY_SERIALIZE_DEFAULT);
 }
 
+/* Shared deserialization of FIDO private key components */
+int
+sshkey_private_deserialize_sk(struct sshbuf *buf, struct sshkey *k)
+{
+	int r;
+
+	if ((k->sk_key_handle = sshbuf_new()) == NULL ||
+	    (k->sk_reserved = sshbuf_new()) == NULL)
+		return SSH_ERR_ALLOC_FAIL;
+	if ((r = sshbuf_get_cstring(buf, &k->sk_application, NULL)) != 0 ||
+	    (r = sshbuf_get_u8(buf, &k->sk_flags)) != 0 ||
+	    (r = sshbuf_get_stringb(buf, k->sk_key_handle)) != 0 ||
+	    (r = sshbuf_get_stringb(buf, k->sk_reserved)) != 0)
+		return r;
+
+	return 0;
+}
+
 int
 sshkey_private_deserialize(struct sshbuf *buf, struct sshkey **kp)
 {
-	char *tname = NULL, *curve = NULL, *xmss_name = NULL;
+	const struct sshkey_impl *impl;
+	char *tname = NULL;
 	char *expect_sk_application = NULL;
-	struct sshkey *k = NULL;
-	size_t pklen = 0, sklen = 0;
-	int type, r = SSH_ERR_INTERNAL_ERROR;
-	u_char *ed25519_pk = NULL, *ed25519_sk = NULL;
 	u_char *expect_ed25519_pk = NULL;
-	u_char *xmss_pk = NULL, *xmss_sk = NULL;
-#ifdef WITH_OPENSSL
-	BIGNUM *exponent = NULL;
-	BIGNUM *rsa_n = NULL, *rsa_e = NULL, *rsa_d = NULL;
-	BIGNUM *rsa_iqmp = NULL, *rsa_p = NULL, *rsa_q = NULL;
-	BIGNUM *dsa_p = NULL, *dsa_q = NULL, *dsa_g = NULL;
-	BIGNUM *dsa_pub_key = NULL, *dsa_priv_key = NULL;
-#endif /* WITH_OPENSSL */
+	struct sshkey *k = NULL;
+	int type, r = SSH_ERR_INTERNAL_ERROR;
 
 	if (kp != NULL)
 		*kp = NULL;
@@ -2480,225 +2489,21 @@ sshkey_private_deserialize(struct sshbuf *buf, struct sshkey **kp)
 		expect_ed25519_pk = k->ed25519_pk;
 		k->sk_application = NULL;
 		k->ed25519_pk = NULL;
+		/* XXX xmss too or refactor */
 	} else {
 		if ((k = sshkey_new(type)) == NULL) {
 			r = SSH_ERR_ALLOC_FAIL;
 			goto out;
 		}
 	}
-	switch (type) {
-#ifdef WITH_OPENSSL
-	case KEY_DSA:
-		if ((r = sshbuf_get_bignum2(buf, &dsa_p)) != 0 ||
-		    (r = sshbuf_get_bignum2(buf, &dsa_q)) != 0 ||
-		    (r = sshbuf_get_bignum2(buf, &dsa_g)) != 0 ||
-		    (r = sshbuf_get_bignum2(buf, &dsa_pub_key)) != 0)
-			goto out;
-		if (!DSA_set0_pqg(k->dsa, dsa_p, dsa_q, dsa_g)) {
-			r = SSH_ERR_LIBCRYPTO_ERROR;
-			goto out;
-		}
-		dsa_p = dsa_q = dsa_g = NULL; /* transferred */
-		if (!DSA_set0_key(k->dsa, dsa_pub_key, NULL)) {
-			r = SSH_ERR_LIBCRYPTO_ERROR;
-			goto out;
-		}
-		dsa_pub_key = NULL; /* transferred */
-		/* FALLTHROUGH */
-	case KEY_DSA_CERT:
-		if ((r = sshbuf_get_bignum2(buf, &dsa_priv_key)) != 0)
-			goto out;
-		if (!DSA_set0_key(k->dsa, NULL, dsa_priv_key)) {
-			r = SSH_ERR_LIBCRYPTO_ERROR;
-			goto out;
-		}
-		dsa_priv_key = NULL; /* transferred */
-		break;
-	case KEY_ECDSA:
-		if ((k->ecdsa_nid = sshkey_ecdsa_nid_from_name(tname)) == -1) {
-			r = SSH_ERR_INVALID_ARGUMENT;
-			goto out;
-		}
-		if ((r = sshbuf_get_cstring(buf, &curve, NULL)) != 0)
-			goto out;
-		if (k->ecdsa_nid != sshkey_curve_name_to_nid(curve)) {
-			r = SSH_ERR_EC_CURVE_MISMATCH;
-			goto out;
-		}
-		k->ecdsa = EC_KEY_new_by_curve_name(k->ecdsa_nid);
-		if (k->ecdsa  == NULL) {
-			r = SSH_ERR_LIBCRYPTO_ERROR;
-			goto out;
-		}
-		if ((r = sshbuf_get_eckey(buf, k->ecdsa)) != 0)
-			goto out;
-		/* FALLTHROUGH */
-	case KEY_ECDSA_CERT:
-		if ((r = sshbuf_get_bignum2(buf, &exponent)) != 0)
-			goto out;
-		if (EC_KEY_set_private_key(k->ecdsa, exponent) != 1) {
-			r = SSH_ERR_LIBCRYPTO_ERROR;
-			goto out;
-		}
-		if ((r = sshkey_ec_validate_public(EC_KEY_get0_group(k->ecdsa),
-		    EC_KEY_get0_public_key(k->ecdsa))) != 0 ||
-		    (r = sshkey_ec_validate_private(k->ecdsa)) != 0)
-			goto out;
-		break;
-	case KEY_ECDSA_SK:
-		if ((k->ecdsa_nid = sshkey_ecdsa_nid_from_name(tname)) == -1) {
-			r = SSH_ERR_INVALID_ARGUMENT;
-			goto out;
-		}
-		if ((r = sshbuf_get_cstring(buf, &curve, NULL)) != 0)
-			goto out;
-		if (k->ecdsa_nid != sshkey_curve_name_to_nid(curve)) {
-			r = SSH_ERR_EC_CURVE_MISMATCH;
-			goto out;
-		}
-		if ((k->sk_key_handle = sshbuf_new()) == NULL ||
-		    (k->sk_reserved = sshbuf_new()) == NULL) {
-			r = SSH_ERR_ALLOC_FAIL;
-			goto out;
-		}
-		k->ecdsa = EC_KEY_new_by_curve_name(k->ecdsa_nid);
-		if (k->ecdsa  == NULL) {
-			r = SSH_ERR_LIBCRYPTO_ERROR;
-			goto out;
-		}
-		if ((r = sshbuf_get_eckey(buf, k->ecdsa)) != 0 ||
-		    (r = sshbuf_get_cstring(buf, &k->sk_application,
-		    NULL)) != 0 ||
-		    (r = sshbuf_get_u8(buf, &k->sk_flags)) != 0 ||
-		    (r = sshbuf_get_stringb(buf, k->sk_key_handle)) != 0 ||
-		    (r = sshbuf_get_stringb(buf, k->sk_reserved)) != 0)
-			goto out;
-		if ((r = sshkey_ec_validate_public(EC_KEY_get0_group(k->ecdsa),
-		    EC_KEY_get0_public_key(k->ecdsa))) != 0)
-			goto out;
-		break;
-	case KEY_ECDSA_SK_CERT:
-		if ((k->sk_key_handle = sshbuf_new()) == NULL ||
-		    (k->sk_reserved = sshbuf_new()) == NULL) {
-			r = SSH_ERR_ALLOC_FAIL;
-			goto out;
-		}
-		if ((r = sshbuf_get_cstring(buf, &k->sk_application,
-		    NULL)) != 0 ||
-		    (r = sshbuf_get_u8(buf, &k->sk_flags)) != 0 ||
-		    (r = sshbuf_get_stringb(buf, k->sk_key_handle)) != 0 ||
-		    (r = sshbuf_get_stringb(buf, k->sk_reserved)) != 0)
-			goto out;
-		if ((r = sshkey_ec_validate_public(EC_KEY_get0_group(k->ecdsa),
-		    EC_KEY_get0_public_key(k->ecdsa))) != 0)
-			goto out;
-		break;
-	case KEY_RSA:
-		if ((r = sshbuf_get_bignum2(buf, &rsa_n)) != 0 ||
-		    (r = sshbuf_get_bignum2(buf, &rsa_e)) != 0)
-			goto out;
-		if (!RSA_set0_key(k->rsa, rsa_n, rsa_e, NULL)) {
-			r = SSH_ERR_LIBCRYPTO_ERROR;
-			goto out;
-		}
-		rsa_n = rsa_e = NULL; /* transferred */
-		/* FALLTHROUGH */
-	case KEY_RSA_CERT:
-		if ((r = sshbuf_get_bignum2(buf, &rsa_d)) != 0 ||
-		    (r = sshbuf_get_bignum2(buf, &rsa_iqmp)) != 0 ||
-		    (r = sshbuf_get_bignum2(buf, &rsa_p)) != 0 ||
-		    (r = sshbuf_get_bignum2(buf, &rsa_q)) != 0)
-			goto out;
-		if (!RSA_set0_key(k->rsa, NULL, NULL, rsa_d)) {
-			r = SSH_ERR_LIBCRYPTO_ERROR;
-			goto out;
-		}
-		rsa_d = NULL; /* transferred */
-		if (!RSA_set0_factors(k->rsa, rsa_p, rsa_q)) {
-			r = SSH_ERR_LIBCRYPTO_ERROR;
-			goto out;
-		}
-		rsa_p = rsa_q = NULL; /* transferred */
-		if ((r = sshkey_check_rsa_length(k, 0)) != 0)
-			goto out;
-		if ((r = ssh_rsa_complete_crt_parameters(k, rsa_iqmp)) != 0)
-			goto out;
-		break;
-#endif /* WITH_OPENSSL */
-	case KEY_ED25519:
-	case KEY_ED25519_CERT:
-		if ((r = sshbuf_get_string(buf, &ed25519_pk, &pklen)) != 0 ||
-		    (r = sshbuf_get_string(buf, &ed25519_sk, &sklen)) != 0)
-			goto out;
-		if (pklen != ED25519_PK_SZ || sklen != ED25519_SK_SZ) {
-			r = SSH_ERR_INVALID_FORMAT;
-			goto out;
-		}
-		k->ed25519_pk = ed25519_pk;
-		k->ed25519_sk = ed25519_sk;
-		ed25519_pk = ed25519_sk = NULL; /* transferred */
-		break;
-	case KEY_ED25519_SK:
-	case KEY_ED25519_SK_CERT:
-		if ((r = sshbuf_get_string(buf, &ed25519_pk, &pklen)) != 0)
-			goto out;
-		if (pklen != ED25519_PK_SZ) {
-			r = SSH_ERR_INVALID_FORMAT;
-			goto out;
-		}
-		if ((k->sk_key_handle = sshbuf_new()) == NULL ||
-		    (k->sk_reserved = sshbuf_new()) == NULL) {
-			r = SSH_ERR_ALLOC_FAIL;
-			goto out;
-		}
-		if ((r = sshbuf_get_cstring(buf, &k->sk_application,
-		    NULL)) != 0 ||
-		    (r = sshbuf_get_u8(buf, &k->sk_flags)) != 0 ||
-		    (r = sshbuf_get_stringb(buf, k->sk_key_handle)) != 0 ||
-		    (r = sshbuf_get_stringb(buf, k->sk_reserved)) != 0)
-			goto out;
-		k->ed25519_pk = ed25519_pk;
-		ed25519_pk = NULL; /* transferred */
-		break;
-#ifdef WITH_XMSS
-	case KEY_XMSS:
-	case KEY_XMSS_CERT:
-		if ((r = sshbuf_get_cstring(buf, &xmss_name, NULL)) != 0 ||
-		    (r = sshbuf_get_string(buf, &xmss_pk, &pklen)) != 0 ||
-		    (r = sshbuf_get_string(buf, &xmss_sk, &sklen)) != 0)
-			goto out;
-		if (type == KEY_XMSS &&
-		    (r = sshkey_xmss_init(k, xmss_name)) != 0)
-			goto out;
-		if (pklen != sshkey_xmss_pklen(k) ||
-		    sklen != sshkey_xmss_sklen(k)) {
-			r = SSH_ERR_INVALID_FORMAT;
-			goto out;
-		}
-		k->xmss_pk = xmss_pk;
-		k->xmss_sk = xmss_sk;
-		xmss_pk = xmss_sk = NULL;
-		/* optional internal state */
-		if ((r = sshkey_xmss_deserialize_state_opt(k, buf)) != 0)
-			goto out;
-		break;
-#endif /* WITH_XMSS */
-	default:
-		r = SSH_ERR_KEY_TYPE_UNKNOWN;
+	if ((impl = sshkey_impl_from_type(type)) == NULL) {
+		r = SSH_ERR_INTERNAL_ERROR;
 		goto out;
 	}
-#ifdef WITH_OPENSSL
-	/* enable blinding */
-	switch (k->type) {
-	case KEY_RSA:
-	case KEY_RSA_CERT:
-		if (RSA_blinding_on(k->rsa, NULL) != 1) {
-			r = SSH_ERR_LIBCRYPTO_ERROR;
-			goto out;
-		}
-		break;
-	}
-#endif /* WITH_OPENSSL */
+	if ((r = impl->funcs->deserialize_private(tname, buf, k)) != 0)
+		goto out;
+
+	/* XXX xmss too or refactor */
 	if ((expect_sk_application != NULL && (k->sk_application == NULL ||
 	    strcmp(expect_sk_application, k->sk_application) != 0)) ||
 	    (expect_ed25519_pk != NULL && (k->ed25519_pk == NULL ||
@@ -2714,27 +2519,7 @@ sshkey_private_deserialize(struct sshbuf *buf, struct sshkey **kp)
 	}
  out:
 	free(tname);
-	free(curve);
-#ifdef WITH_OPENSSL
-	BN_clear_free(exponent);
-	BN_clear_free(dsa_p);
-	BN_clear_free(dsa_q);
-	BN_clear_free(dsa_g);
-	BN_clear_free(dsa_pub_key);
-	BN_clear_free(dsa_priv_key);
-	BN_clear_free(rsa_n);
-	BN_clear_free(rsa_e);
-	BN_clear_free(rsa_d);
-	BN_clear_free(rsa_p);
-	BN_clear_free(rsa_q);
-	BN_clear_free(rsa_iqmp);
-#endif /* WITH_OPENSSL */
 	sshkey_free(k);
-	freezero(ed25519_pk, pklen);
-	freezero(ed25519_sk, sklen);
-	free(xmss_name);
-	freezero(xmss_pk, pklen);
-	freezero(xmss_sk, sklen);
 	free(expect_sk_application);
 	free(expect_ed25519_pk);
 	return r;

--- a/sshkey.c
+++ b/sshkey.c
@@ -2009,6 +2009,7 @@ sshkey_sign(struct sshkey *key,
 {
 	int was_shielded = sshkey_is_shielded(key);
 	int r2, r = SSH_ERR_INTERNAL_ERROR;
+	const struct sshkey_impl *impl;
 
 	if (sigp != NULL)
 		*sigp = NULL;
@@ -2016,43 +2017,20 @@ sshkey_sign(struct sshkey *key,
 		*lenp = 0;
 	if (datalen > SSH_KEY_MAX_SIGN_DATA_SIZE)
 		return SSH_ERR_INVALID_ARGUMENT;
+	if ((impl = sshkey_impl_from_key(key)) == NULL)
+		return SSH_ERR_KEY_TYPE_UNKNOWN;
 	if ((r = sshkey_unshield_private(key)) != 0)
 		return r;
-	switch (key->type) {
-#ifdef WITH_OPENSSL
-	case KEY_DSA_CERT:
-	case KEY_DSA:
-		r = ssh_dss_sign(key, sigp, lenp, data, datalen, compat);
-		break;
-	case KEY_ECDSA_CERT:
-	case KEY_ECDSA:
-		r = ssh_ecdsa_sign(key, sigp, lenp, data, datalen, compat);
-		break;
-	case KEY_RSA_CERT:
-	case KEY_RSA:
-		r = ssh_rsa_sign(key, sigp, lenp, data, datalen, alg);
-		break;
-#endif /* WITH_OPENSSL */
-	case KEY_ED25519:
-	case KEY_ED25519_CERT:
-		r = ssh_ed25519_sign(key, sigp, lenp, data, datalen, compat);
-		break;
-	case KEY_ED25519_SK:
-	case KEY_ED25519_SK_CERT:
-	case KEY_ECDSA_SK_CERT:
-	case KEY_ECDSA_SK:
+	if (sshkey_is_sk(key)) {
 		r = sshsk_sign(sk_provider, key, sigp, lenp, data,
 		    datalen, compat, sk_pin);
-		break;
-#ifdef WITH_XMSS
-	case KEY_XMSS:
-	case KEY_XMSS_CERT:
-		r = ssh_xmss_sign(key, sigp, lenp, data, datalen, compat);
-		break;
-#endif /* WITH_XMSS */
-	default:
-		r = SSH_ERR_KEY_TYPE_UNKNOWN;
-		break;
+	} else {
+		if (impl->funcs->sign == NULL)
+			r = SSH_ERR_SIGN_ALG_UNSUPPORTED;
+		else {
+			r = impl->funcs->sign(key, sigp, lenp, data, datalen,
+			    alg, sk_provider, sk_pin, compat);
+		 }
 	}
 	if (was_shielded && (r2 = sshkey_shield_private(key)) != 0)
 		return r2;
@@ -2069,41 +2047,16 @@ sshkey_verify(const struct sshkey *key,
     const u_char *data, size_t dlen, const char *alg, u_int compat,
     struct sshkey_sig_details **detailsp)
 {
+	const struct sshkey_impl *impl;
+
 	if (detailsp != NULL)
 		*detailsp = NULL;
 	if (siglen == 0 || dlen > SSH_KEY_MAX_SIGN_DATA_SIZE)
 		return SSH_ERR_INVALID_ARGUMENT;
-	switch (key->type) {
-#ifdef WITH_OPENSSL
-	case KEY_DSA_CERT:
-	case KEY_DSA:
-		return ssh_dss_verify(key, sig, siglen, data, dlen, compat);
-	case KEY_ECDSA_CERT:
-	case KEY_ECDSA:
-		return ssh_ecdsa_verify(key, sig, siglen, data, dlen, compat);
-	case KEY_ECDSA_SK_CERT:
-	case KEY_ECDSA_SK:
-		return ssh_ecdsa_sk_verify(key, sig, siglen, data, dlen,
-		    compat, detailsp);
-	case KEY_RSA_CERT:
-	case KEY_RSA:
-		return ssh_rsa_verify(key, sig, siglen, data, dlen, alg);
-#endif /* WITH_OPENSSL */
-	case KEY_ED25519:
-	case KEY_ED25519_CERT:
-		return ssh_ed25519_verify(key, sig, siglen, data, dlen, compat);
-	case KEY_ED25519_SK:
-	case KEY_ED25519_SK_CERT:
-		return ssh_ed25519_sk_verify(key, sig, siglen, data, dlen,
-		    compat, detailsp);
-#ifdef WITH_XMSS
-	case KEY_XMSS:
-	case KEY_XMSS_CERT:
-		return ssh_xmss_verify(key, sig, siglen, data, dlen, compat);
-#endif /* WITH_XMSS */
-	default:
+	if ((impl = sshkey_impl_from_key(key)) == NULL)
 		return SSH_ERR_KEY_TYPE_UNKNOWN;
-	}
+	return impl->funcs->verify(key, sig, siglen, data, dlen,
+	    alg, compat, detailsp);
 }
 
 /* Convert a plain key to their _CERT equivalent */

--- a/sshkey.c
+++ b/sshkey.c
@@ -1406,130 +1406,30 @@ sshkey_cert_copy(const struct sshkey *from_key, struct sshkey *to_key)
 }
 
 int
+sshkey_copy_public_sk(const struct sshkey *from, struct sshkey *to)
+{
+	/* Append security-key application string */
+	if ((to->sk_application = strdup(from->sk_application)) == NULL)
+		return SSH_ERR_ALLOC_FAIL;
+	return 0;
+}
+
+int
 sshkey_from_private(const struct sshkey *k, struct sshkey **pkp)
 {
 	struct sshkey *n = NULL;
 	int r = SSH_ERR_INTERNAL_ERROR;
-#ifdef WITH_OPENSSL
-	const BIGNUM *rsa_n, *rsa_e;
-	BIGNUM *rsa_n_dup = NULL, *rsa_e_dup = NULL;
-	const BIGNUM *dsa_p, *dsa_q, *dsa_g, *dsa_pub_key;
-	BIGNUM *dsa_p_dup = NULL, *dsa_q_dup = NULL, *dsa_g_dup = NULL;
-	BIGNUM *dsa_pub_key_dup = NULL;
-#endif /* WITH_OPENSSL */
+	const struct sshkey_impl *impl;
 
 	*pkp = NULL;
+	if ((impl = sshkey_impl_from_key(k)) == NULL)
+		return SSH_ERR_KEY_TYPE_UNKNOWN;
 	if ((n = sshkey_new(k->type)) == NULL) {
 		r = SSH_ERR_ALLOC_FAIL;
 		goto out;
 	}
-	switch (k->type) {
-#ifdef WITH_OPENSSL
-	case KEY_DSA:
-	case KEY_DSA_CERT:
-		DSA_get0_pqg(k->dsa, &dsa_p, &dsa_q, &dsa_g);
-		DSA_get0_key(k->dsa, &dsa_pub_key, NULL);
-		if ((dsa_p_dup = BN_dup(dsa_p)) == NULL ||
-		    (dsa_q_dup = BN_dup(dsa_q)) == NULL ||
-		    (dsa_g_dup = BN_dup(dsa_g)) == NULL ||
-		    (dsa_pub_key_dup = BN_dup(dsa_pub_key)) == NULL) {
-			r = SSH_ERR_ALLOC_FAIL;
-			goto out;
-		}
-		if (!DSA_set0_pqg(n->dsa, dsa_p_dup, dsa_q_dup, dsa_g_dup)) {
-			r = SSH_ERR_LIBCRYPTO_ERROR;
-			goto out;
-		}
-		dsa_p_dup = dsa_q_dup = dsa_g_dup = NULL; /* transferred */
-		if (!DSA_set0_key(n->dsa, dsa_pub_key_dup, NULL)) {
-			r = SSH_ERR_LIBCRYPTO_ERROR;
-			goto out;
-		}
-		dsa_pub_key_dup = NULL; /* transferred */
-
-		break;
-	case KEY_ECDSA:
-	case KEY_ECDSA_CERT:
-	case KEY_ECDSA_SK:
-	case KEY_ECDSA_SK_CERT:
-		n->ecdsa_nid = k->ecdsa_nid;
-		n->ecdsa = EC_KEY_new_by_curve_name(k->ecdsa_nid);
-		if (n->ecdsa == NULL) {
-			r = SSH_ERR_ALLOC_FAIL;
-			goto out;
-		}
-		if (EC_KEY_set_public_key(n->ecdsa,
-		    EC_KEY_get0_public_key(k->ecdsa)) != 1) {
-			r = SSH_ERR_LIBCRYPTO_ERROR;
-			goto out;
-		}
-		if (k->type != KEY_ECDSA_SK && k->type != KEY_ECDSA_SK_CERT)
-			break;
-		/* Append security-key application string */
-		if ((n->sk_application = strdup(k->sk_application)) == NULL)
-			goto out;
-		break;
-	case KEY_RSA:
-	case KEY_RSA_CERT:
-		RSA_get0_key(k->rsa, &rsa_n, &rsa_e, NULL);
-		if ((rsa_n_dup = BN_dup(rsa_n)) == NULL ||
-		    (rsa_e_dup = BN_dup(rsa_e)) == NULL) {
-			r = SSH_ERR_ALLOC_FAIL;
-			goto out;
-		}
-		if (!RSA_set0_key(n->rsa, rsa_n_dup, rsa_e_dup, NULL)) {
-			r = SSH_ERR_LIBCRYPTO_ERROR;
-			goto out;
-		}
-		rsa_n_dup = rsa_e_dup = NULL; /* transferred */
-		break;
-#endif /* WITH_OPENSSL */
-	case KEY_ED25519:
-	case KEY_ED25519_CERT:
-	case KEY_ED25519_SK:
-	case KEY_ED25519_SK_CERT:
-		if (k->ed25519_pk != NULL) {
-			if ((n->ed25519_pk = malloc(ED25519_PK_SZ)) == NULL) {
-				r = SSH_ERR_ALLOC_FAIL;
-				goto out;
-			}
-			memcpy(n->ed25519_pk, k->ed25519_pk, ED25519_PK_SZ);
-		}
-		if (k->type != KEY_ED25519_SK &&
-		    k->type != KEY_ED25519_SK_CERT)
-			break;
-		/* Append security-key application string */
-		if ((n->sk_application = strdup(k->sk_application)) == NULL)
-			goto out;
-		break;
-#ifdef WITH_XMSS
-	case KEY_XMSS:
-	case KEY_XMSS_CERT:
-		if ((r = sshkey_xmss_init(n, k->xmss_name)) != 0)
-			goto out;
-		if (k->xmss_pk != NULL) {
-			u_int32_t left;
-			size_t pklen = sshkey_xmss_pklen(k);
-			if (pklen == 0 || sshkey_xmss_pklen(n) != pklen) {
-				r = SSH_ERR_INTERNAL_ERROR;
-				goto out;
-			}
-			if ((n->xmss_pk = malloc(pklen)) == NULL) {
-				r = SSH_ERR_ALLOC_FAIL;
-				goto out;
-			}
-			memcpy(n->xmss_pk, k->xmss_pk, pklen);
-			/* simulate number of signatures left on pubkey */
-			left = sshkey_xmss_signatures_left(k);
-			if (left)
-				sshkey_xmss_enable_maxsign(n, left);
-		}
-		break;
-#endif /* WITH_XMSS */
-	default:
-		r = SSH_ERR_KEY_TYPE_UNKNOWN;
+	if ((r = impl->funcs->copy_public(k, n)) != 0)
 		goto out;
-	}
 	if (sshkey_is_cert(k) && (r = sshkey_cert_copy(k, n)) != 0)
 		goto out;
 	/* success */
@@ -1538,15 +1438,6 @@ sshkey_from_private(const struct sshkey *k, struct sshkey **pkp)
 	r = 0;
  out:
 	sshkey_free(n);
-#ifdef WITH_OPENSSL
-	BN_clear_free(rsa_n_dup);
-	BN_clear_free(rsa_e_dup);
-	BN_clear_free(dsa_p_dup);
-	BN_clear_free(dsa_q_dup);
-	BN_clear_free(dsa_g_dup);
-	BN_clear_free(dsa_pub_key_dup);
-#endif /* WITH_OPENSSL */
-
 	return r;
 }
 

--- a/sshkey.c
+++ b/sshkey.c
@@ -87,97 +87,118 @@ static int sshkey_from_blob_internal(struct sshbuf *buf,
     struct sshkey **keyp, int allow_cert);
 
 /* Supported key types */
-struct keytype {
-	const char *name;
-	const char *shortname;
-	const char *sigalg;
-	int type;
-	int nid;
-	int cert;
-	int sigonly;
-};
-static const struct keytype keytypes[] = {
-	{ "ssh-ed25519", "ED25519", NULL, KEY_ED25519, 0, 0, 0 },
-	{ "ssh-ed25519-cert-v01@openssh.com", "ED25519-CERT", NULL,
-	    KEY_ED25519_CERT, 0, 1, 0 },
-	{ "sk-ssh-ed25519@openssh.com", "ED25519-SK", NULL,
-	    KEY_ED25519_SK, 0, 0, 0 },
-	{ "sk-ssh-ed25519-cert-v01@openssh.com", "ED25519-SK-CERT", NULL,
-	    KEY_ED25519_SK_CERT, 0, 1, 0 },
-#ifdef WITH_XMSS
-	{ "ssh-xmss@openssh.com", "XMSS", NULL, KEY_XMSS, 0, 0, 0 },
-	{ "ssh-xmss-cert-v01@openssh.com", "XMSS-CERT", NULL,
-	    KEY_XMSS_CERT, 0, 1, 0 },
-#endif /* WITH_XMSS */
+extern const struct sshkey_impl sshkey_ed25519_impl;
+extern const struct sshkey_impl sshkey_ed25519_cert_impl;
+extern const struct sshkey_impl sshkey_ed25519_sk_impl;
+extern const struct sshkey_impl sshkey_ed25519_sk_cert_impl;
 #ifdef WITH_OPENSSL
-	{ "ssh-rsa", "RSA", NULL, KEY_RSA, 0, 0, 0 },
-	{ "rsa-sha2-256", "RSA", NULL, KEY_RSA, 0, 0, 1 },
-	{ "rsa-sha2-512", "RSA", NULL, KEY_RSA, 0, 0, 1 },
-	{ "ssh-dss", "DSA", NULL, KEY_DSA, 0, 0, 0 },
-	{ "ecdsa-sha2-nistp256", "ECDSA", NULL,
-	    KEY_ECDSA, NID_X9_62_prime256v1, 0, 0 },
-	{ "ecdsa-sha2-nistp384", "ECDSA", NULL,
-	    KEY_ECDSA, NID_secp384r1, 0, 0 },
-	{ "ecdsa-sha2-nistp521", "ECDSA", NULL,
-	    KEY_ECDSA, NID_secp521r1, 0, 0 },
-	{ "sk-ecdsa-sha2-nistp256@openssh.com", "ECDSA-SK", NULL,
-	    KEY_ECDSA_SK, NID_X9_62_prime256v1, 0, 0 },
-	{ "webauthn-sk-ecdsa-sha2-nistp256@openssh.com", "ECDSA-SK", NULL,
-	    KEY_ECDSA_SK, NID_X9_62_prime256v1, 0, 1 },
-	{ "ssh-rsa-cert-v01@openssh.com", "RSA-CERT", NULL,
-	    KEY_RSA_CERT, 0, 1, 0 },
-	{ "rsa-sha2-256-cert-v01@openssh.com", "RSA-CERT",
-	    "rsa-sha2-256", KEY_RSA_CERT, 0, 1, 1 },
-	{ "rsa-sha2-512-cert-v01@openssh.com", "RSA-CERT",
-	    "rsa-sha2-512", KEY_RSA_CERT, 0, 1, 1 },
-	{ "ssh-dss-cert-v01@openssh.com", "DSA-CERT", NULL,
-	    KEY_DSA_CERT, 0, 1, 0 },
-	{ "ecdsa-sha2-nistp256-cert-v01@openssh.com", "ECDSA-CERT", NULL,
-	    KEY_ECDSA_CERT, NID_X9_62_prime256v1, 1, 0 },
-	{ "ecdsa-sha2-nistp384-cert-v01@openssh.com", "ECDSA-CERT", NULL,
-	    KEY_ECDSA_CERT, NID_secp384r1, 1, 0 },
-	{ "ecdsa-sha2-nistp521-cert-v01@openssh.com", "ECDSA-CERT", NULL,
-	    KEY_ECDSA_CERT, NID_secp521r1, 1, 0 },
-	{ "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com", "ECDSA-SK-CERT", NULL,
-	    KEY_ECDSA_SK_CERT, NID_X9_62_prime256v1, 1, 0 },
+extern const struct sshkey_impl sshkey_ecdsa_sk_impl;
+extern const struct sshkey_impl sshkey_ecdsa_sk_cert_impl;
+extern const struct sshkey_impl sshkey_ecdsa_sk_webauthn_impl;
+extern const struct sshkey_impl sshkey_ecdsa_nistp256_impl;
+extern const struct sshkey_impl sshkey_ecdsa_nistp256_cert_impl;
+extern const struct sshkey_impl sshkey_ecdsa_nistp384_impl;
+extern const struct sshkey_impl sshkey_ecdsa_nistp384_cert_impl;
+extern const struct sshkey_impl sshkey_ecdsa_nistp521_impl;
+extern const struct sshkey_impl sshkey_ecdsa_nistp521_cert_impl;
+extern const struct sshkey_impl sshkey_rsa_impl;
+extern const struct sshkey_impl sshkey_rsa_cert_impl;
+extern const struct sshkey_impl sshkey_rsa_sha256_impl;
+extern const struct sshkey_impl sshkey_rsa_sha256_cert_impl;
+extern const struct sshkey_impl sshkey_rsa_sha512_impl;
+extern const struct sshkey_impl sshkey_rsa_sha512_cert_impl;
+extern const struct sshkey_impl sshkey_dss_impl;
+extern const struct sshkey_impl sshkey_dsa_cert_impl;
 #endif /* WITH_OPENSSL */
-	{ NULL, NULL, NULL, -1, -1, 0, 0 }
+#ifdef WITH_XMSS
+extern const struct sshkey_impl sshkey_xmss_impl;
+extern const struct sshkey_impl sshkey_xmss_cert_impl;
+#endif
+
+const struct sshkey_impl * const keyimpls[] = {
+	&sshkey_ed25519_impl,
+	&sshkey_ed25519_cert_impl,
+	&sshkey_ed25519_sk_impl,
+	&sshkey_ed25519_sk_cert_impl,
+#ifdef WITH_OPENSSL
+	&sshkey_ecdsa_nistp256_impl,
+	&sshkey_ecdsa_nistp256_cert_impl,
+	&sshkey_ecdsa_nistp384_impl,
+	&sshkey_ecdsa_nistp384_cert_impl,
+	&sshkey_ecdsa_nistp521_impl,
+	&sshkey_ecdsa_nistp521_cert_impl,
+	&sshkey_ecdsa_sk_impl,
+	&sshkey_ecdsa_sk_cert_impl,
+	&sshkey_ecdsa_sk_webauthn_impl,
+	&sshkey_dss_impl,
+	&sshkey_dsa_cert_impl,
+	&sshkey_rsa_impl,
+	&sshkey_rsa_cert_impl,
+	&sshkey_rsa_sha256_impl,
+	&sshkey_rsa_sha256_cert_impl,
+	&sshkey_rsa_sha512_impl,
+	&sshkey_rsa_sha512_cert_impl,
+#endif /* WITH_OPENSSL */
+#ifdef WITH_XMSS
+	&sshkey_xmss_impl,
+	&sshkey_xmss_cert_impl,
+#endif
+	NULL
 };
+
+static const struct sshkey_impl *
+sshkey_impl_from_type(int type)
+{
+	int i;
+
+	for (i = 0; keyimpls[i] != NULL; i++) {
+		if (keyimpls[i]->type == type)
+			return keyimpls[i];
+	}
+	return NULL;
+}
+
+static const struct sshkey_impl *
+sshkey_impl_from_type_nid(int type, int nid)
+{
+	int i;
+
+	for (i = 0; keyimpls[i] != NULL; i++) {
+		if (keyimpls[i]->type == type &&
+		    (keyimpls[i]->nid == 0 || keyimpls[i]->nid == nid))
+			return keyimpls[i];
+	}
+	return NULL;
+}
 
 const char *
 sshkey_type(const struct sshkey *k)
 {
-	const struct keytype *kt;
+	const struct sshkey_impl *impl;
 
-	for (kt = keytypes; kt->type != -1; kt++) {
-		if (kt->type == k->type)
-			return kt->shortname;
-	}
-	return "unknown";
+	if ((impl = sshkey_impl_from_type(k->type)) == NULL)
+		return "unknown";
+	return impl->shortname;
 }
 
 static const char *
 sshkey_ssh_name_from_type_nid(int type, int nid)
 {
-	const struct keytype *kt;
+	const struct sshkey_impl *impl;
 
-	for (kt = keytypes; kt->type != -1; kt++) {
-		if (kt->type == type && (kt->nid == 0 || kt->nid == nid))
-			return kt->name;
-	}
-	return "ssh-unknown";
+	if ((impl = sshkey_impl_from_type_nid(type, nid)) == NULL)
+		return "ssh-unknown";
+	return impl->name;
 }
 
 int
 sshkey_type_is_cert(int type)
 {
-	const struct keytype *kt;
+	const struct sshkey_impl *impl;
 
-	for (kt = keytypes; kt->type != -1; kt++) {
-		if (kt->type == type)
-			return kt->cert;
-	}
-	return 0;
+	if ((impl = sshkey_impl_from_type(type)) == NULL)
+		return 0;
+	return impl->cert;
 }
 
 const char *
@@ -196,13 +217,15 @@ sshkey_ssh_name_plain(const struct sshkey *k)
 int
 sshkey_type_from_name(const char *name)
 {
-	const struct keytype *kt;
+	int i;
+	const struct sshkey_impl *impl;
 
-	for (kt = keytypes; kt->type != -1; kt++) {
+	for (i = 0; keyimpls[i] != NULL; i++) {
+		impl = keyimpls[i];
 		/* Only allow shortname matches for plain key types */
-		if ((kt->name != NULL && strcmp(name, kt->name) == 0) ||
-		    (!kt->cert && strcasecmp(kt->shortname, name) == 0))
-			return kt->type;
+		if ((impl->name != NULL && strcmp(name, impl->name) == 0) ||
+		    (!impl->cert && strcasecmp(impl->shortname, name) == 0))
+			return impl->type;
 	}
 	return KEY_UNSPEC;
 }
@@ -223,13 +246,14 @@ key_type_is_ecdsa_variant(int type)
 int
 sshkey_ecdsa_nid_from_name(const char *name)
 {
-	const struct keytype *kt;
+	int i;
 
-	for (kt = keytypes; kt->type != -1; kt++) {
-		if (!key_type_is_ecdsa_variant(kt->type))
+	for (i = 0; keyimpls[i] != NULL; i++) {
+		if (!key_type_is_ecdsa_variant(keyimpls[i]->type))
 			continue;
-		if (kt->name != NULL && strcmp(name, kt->name) == 0)
-			return kt->nid;
+		if (keyimpls[i]->name != NULL &&
+		    strcmp(name, keyimpls[i]->name) == 0)
+			return keyimpls[i]->nid;
 	}
 	return -1;
 }
@@ -261,25 +285,26 @@ char *
 sshkey_alg_list(int certs_only, int plain_only, int include_sigonly, char sep)
 {
 	char *tmp, *ret = NULL;
-	size_t nlen, rlen = 0;
-	const struct keytype *kt;
+	size_t i, nlen, rlen = 0;
+	const struct sshkey_impl *impl;
 
-	for (kt = keytypes; kt->type != -1; kt++) {
-		if (kt->name == NULL)
+	for (i = 0; keyimpls[i] != NULL; i++) {
+		impl = keyimpls[i];
+		if (impl->name == NULL)
 			continue;
-		if (!include_sigonly && kt->sigonly)
+		if (!include_sigonly && impl->sigonly)
 			continue;
-		if ((certs_only && !kt->cert) || (plain_only && kt->cert))
+		if ((certs_only && !impl->cert) || (plain_only && impl->cert))
 			continue;
 		if (ret != NULL)
 			ret[rlen++] = sep;
-		nlen = strlen(kt->name);
+		nlen = strlen(impl->name);
 		if ((tmp = realloc(ret, rlen + nlen + 2)) == NULL) {
 			free(ret);
 			return NULL;
 		}
 		ret = tmp;
-		memcpy(ret + rlen, kt->name, nlen + 1);
+		memcpy(ret + rlen, impl->name, nlen + 1);
 		rlen += nlen;
 	}
 	return ret;
@@ -289,8 +314,8 @@ int
 sshkey_names_valid2(const char *names, int allow_wildcard)
 {
 	char *s, *cp, *p;
-	const struct keytype *kt;
-	int type;
+	const struct sshkey_impl *impl;
+	int i, type;
 
 	if (names == NULL || strcmp(names, "") == 0)
 		return 0;
@@ -306,12 +331,15 @@ sshkey_names_valid2(const char *names, int allow_wildcard)
 				 * If any has a positive or negative match then
 				 * the component is accepted.
 				 */
-				for (kt = keytypes; kt->type != -1; kt++) {
-					if (match_pattern_list(kt->name,
-					    p, 0) != 0)
+				impl = NULL;
+				for (i = 0; keyimpls[i] != NULL; i++) {
+					if (match_pattern_list(
+					    keyimpls[i]->name, p, 0) != 0) {
+						impl = keyimpls[i];
 						break;
+					}
 				}
-				if (kt->type != -1)
+				if (impl != NULL)
 					continue;
 			}
 			free(s);
@@ -325,56 +353,24 @@ sshkey_names_valid2(const char *names, int allow_wildcard)
 u_int
 sshkey_size(const struct sshkey *k)
 {
-#ifdef WITH_OPENSSL
-	const BIGNUM *rsa_n, *dsa_p;
-#endif /* WITH_OPENSSL */
+	const struct sshkey_impl *impl;
 
-	switch (k->type) {
-#ifdef WITH_OPENSSL
-	case KEY_RSA:
-	case KEY_RSA_CERT:
-		if (k->rsa == NULL)
-			return 0;
-		RSA_get0_key(k->rsa, &rsa_n, NULL, NULL);
-		return BN_num_bits(rsa_n);
-	case KEY_DSA:
-	case KEY_DSA_CERT:
-		if (k->dsa == NULL)
-			return 0;
-		DSA_get0_pqg(k->dsa, &dsa_p, NULL, NULL);
-		return BN_num_bits(dsa_p);
-	case KEY_ECDSA:
-	case KEY_ECDSA_CERT:
-	case KEY_ECDSA_SK:
-	case KEY_ECDSA_SK_CERT:
-		return sshkey_curve_nid_to_bits(k->ecdsa_nid);
-#endif /* WITH_OPENSSL */
-	case KEY_ED25519:
-	case KEY_ED25519_CERT:
-	case KEY_ED25519_SK:
-	case KEY_ED25519_SK_CERT:
-	case KEY_XMSS:
-	case KEY_XMSS_CERT:
-		return 256;	/* XXX */
-	}
-	return 0;
+	if ((impl = sshkey_impl_from_type_nid(k->type, k->ecdsa_nid)) == NULL)
+		return 0;
+	if (impl->funcs->size != NULL)
+		return impl->funcs->size(k);
+	return impl->keybits;
 }
 
 static int
 sshkey_type_is_valid_ca(int type)
 {
-	switch (type) {
-	case KEY_RSA:
-	case KEY_DSA:
-	case KEY_ECDSA:
-	case KEY_ECDSA_SK:
-	case KEY_ED25519:
-	case KEY_ED25519_SK:
-	case KEY_XMSS:
-		return 1;
-	default:
+	const struct sshkey_impl *impl;
+
+	if ((impl = sshkey_impl_from_type(type)) == NULL)
 		return 0;
-	}
+	/* All non-certificate types may act as CAs */
+	return !impl->cert;
 }
 
 int
@@ -544,63 +540,23 @@ struct sshkey *
 sshkey_new(int type)
 {
 	struct sshkey *k;
-#ifdef WITH_OPENSSL
-	RSA *rsa;
-	DSA *dsa;
-#endif /* WITH_OPENSSL */
+	const struct sshkey_impl *impl = NULL;
 
+	if (type != KEY_UNSPEC &&
+	    (impl = sshkey_impl_from_type(type)) == NULL)
+		return NULL;
+
+	/* All non-certificate types may act as CAs */
 	if ((k = calloc(1, sizeof(*k))) == NULL)
 		return NULL;
 	k->type = type;
-	k->ecdsa = NULL;
 	k->ecdsa_nid = -1;
-	k->dsa = NULL;
-	k->rsa = NULL;
-	k->cert = NULL;
-	k->ed25519_sk = NULL;
-	k->ed25519_pk = NULL;
-	k->xmss_sk = NULL;
-	k->xmss_pk = NULL;
-	switch (k->type) {
-#ifdef WITH_OPENSSL
-	case KEY_RSA:
-	case KEY_RSA_CERT:
-		if ((rsa = RSA_new()) == NULL) {
+	if (impl != NULL && impl->funcs->alloc != NULL) {
+		if (impl->funcs->alloc(k) != 0) {
 			free(k);
 			return NULL;
 		}
-		k->rsa = rsa;
-		break;
-	case KEY_DSA:
-	case KEY_DSA_CERT:
-		if ((dsa = DSA_new()) == NULL) {
-			free(k);
-			return NULL;
-		}
-		k->dsa = dsa;
-		break;
-	case KEY_ECDSA:
-	case KEY_ECDSA_CERT:
-	case KEY_ECDSA_SK:
-	case KEY_ECDSA_SK_CERT:
-		/* Cannot do anything until we know the group */
-		break;
-#endif /* WITH_OPENSSL */
-	case KEY_ED25519:
-	case KEY_ED25519_CERT:
-	case KEY_ED25519_SK:
-	case KEY_ED25519_SK_CERT:
-	case KEY_XMSS:
-	case KEY_XMSS_CERT:
-		/* no need to prealloc */
-		break;
-	case KEY_UNSPEC:
-		break;
-	default:
-		free(k);
-		return NULL;
 	}
-
 	if (sshkey_is_cert(k)) {
 		if ((k->cert = cert_new()) == NULL) {
 			sshkey_free(k);
@@ -614,64 +570,13 @@ sshkey_new(int type)
 void
 sshkey_free(struct sshkey *k)
 {
+	const struct sshkey_impl *impl;
+
 	if (k == NULL)
 		return;
-	switch (k->type) {
-#ifdef WITH_OPENSSL
-	case KEY_RSA:
-	case KEY_RSA_CERT:
-		RSA_free(k->rsa);
-		k->rsa = NULL;
-		break;
-	case KEY_DSA:
-	case KEY_DSA_CERT:
-		DSA_free(k->dsa);
-		k->dsa = NULL;
-		break;
-	case KEY_ECDSA_SK:
-	case KEY_ECDSA_SK_CERT:
-		free(k->sk_application);
-		sshbuf_free(k->sk_key_handle);
-		sshbuf_free(k->sk_reserved);
-		/* FALLTHROUGH */
-	case KEY_ECDSA:
-	case KEY_ECDSA_CERT:
-		EC_KEY_free(k->ecdsa);
-		k->ecdsa = NULL;
-		break;
-#endif /* WITH_OPENSSL */
-	case KEY_ED25519_SK:
-	case KEY_ED25519_SK_CERT:
-		free(k->sk_application);
-		sshbuf_free(k->sk_key_handle);
-		sshbuf_free(k->sk_reserved);
-		/* FALLTHROUGH */
-	case KEY_ED25519:
-	case KEY_ED25519_CERT:
-		freezero(k->ed25519_pk, ED25519_PK_SZ);
-		k->ed25519_pk = NULL;
-		freezero(k->ed25519_sk, ED25519_SK_SZ);
-		k->ed25519_sk = NULL;
-		break;
-#ifdef WITH_XMSS
-	case KEY_XMSS:
-	case KEY_XMSS_CERT:
-		freezero(k->xmss_pk, sshkey_xmss_pklen(k));
-		k->xmss_pk = NULL;
-		freezero(k->xmss_sk, sshkey_xmss_sklen(k));
-		k->xmss_sk = NULL;
-		sshkey_xmss_free_state(k);
-		free(k->xmss_name);
-		k->xmss_name = NULL;
-		free(k->xmss_filename);
-		k->xmss_filename = NULL;
-		break;
-#endif /* WITH_XMSS */
-	case KEY_UNSPEC:
-		break;
-	default:
-		break;
-	}
+	if ((impl = sshkey_impl_from_type(k->type)) != NULL &&
+	    impl->funcs->cleanup != NULL)
+		impl->funcs->cleanup(k);
 	if (sshkey_is_cert(k))
 		cert_free(k->cert);
 	freezero(k->shielded_private, k->shielded_len);
@@ -1284,16 +1189,18 @@ sshkey_fingerprint(const struct sshkey *k, int dgst_alg,
 static int
 peek_type_nid(const char *s, size_t l, int *nid)
 {
-	const struct keytype *kt;
+	const struct sshkey_impl *impl;
+	int i;
 
-	for (kt = keytypes; kt->type != -1; kt++) {
-		if (kt->name == NULL || strlen(kt->name) != l)
+	for (i = 0; keyimpls[i] != NULL; i++) {
+		impl = keyimpls[i];
+		if (impl->name == NULL || strlen(impl->name) != l)
 			continue;
-		if (memcmp(s, kt->name, l) == 0) {
+		if (memcmp(s, impl->name, l) == 0) {
 			*nid = -1;
-			if (key_type_is_ecdsa_variant(kt->type))
-				*nid = kt->nid;
-			return kt->type;
+			if (key_type_is_ecdsa_variant(impl->type))
+				*nid = impl->nid;
+			return impl->type;
 		}
 	}
 	return KEY_UNSPEC;
@@ -2685,17 +2592,19 @@ sshkey_check_cert_sigtype(const struct sshkey *key, const char *allowed)
 const char *
 sshkey_sigalg_by_name(const char *name)
 {
-	const struct keytype *kt;
+	const struct sshkey_impl *impl;
+	int i;
 
-	for (kt = keytypes; kt->type != -1; kt++) {
-		if (strcmp(kt->name, name) != 0)
+	for (i = 0; keyimpls[i] != NULL; i++) {
+		impl = keyimpls[i];
+		if (strcmp(impl->name, name) != 0)
 			continue;
-		if (kt->sigalg != NULL)
-			return kt->sigalg;
-		if (!kt->cert)
-			return kt->name;
+		if (impl->sigalg != NULL)
+			return impl->sigalg;
+		if (!impl->cert)
+			return impl->name;
 		return sshkey_ssh_name_from_type_nid(
-		    sshkey_type_plain(kt->type), kt->nid);
+		    sshkey_type_plain(impl->type), impl->nid);
 	}
 	return NULL;
 }

--- a/sshkey.h
+++ b/sshkey.h
@@ -167,6 +167,8 @@ struct sshkey_impl_funcs {
 	    enum sshkey_serialize_rep);
 	int (*deserialize_public)(const char *, struct sshbuf *,
 	    struct sshkey *);
+	int (*serialize_private)(const struct sshkey *, struct sshbuf *,
+	    enum sshkey_serialize_rep);
 	int (*generate)(struct sshkey *, int);	/* optional */
 	int (*copy_public)(const struct sshkey *, struct sshkey *);
 	int (*sign)(struct sshkey *, u_char **, size_t *,
@@ -318,6 +320,8 @@ void	sshkey_sk_cleanup(struct sshkey *k);
 int	sshkey_serialize_sk(const struct sshkey *key, struct sshbuf *b);
 int	sshkey_copy_public_sk(const struct sshkey *from, struct sshkey *to);
 int	sshkey_deserialize_sk(struct sshbuf *b, struct sshkey *key);
+int	sshkey_serialize_private_sk(const struct sshkey *key,
+    struct sshbuf *buf);
 #ifdef WITH_OPENSSL
 int	check_rsa_length(const RSA *rsa); /* XXX remove */
 #endif

--- a/sshkey.h
+++ b/sshkey.h
@@ -165,6 +165,7 @@ struct sshkey_impl_funcs {
 	int (*equal)(const struct sshkey *, const struct sshkey *);
 	int (*serialize_public)(const struct sshkey *, struct sshbuf *,
 	    const char *, enum sshkey_serialize_rep);
+	int (*generate)(struct sshkey *, int);	/* optional */
 };
 
 struct sshkey_impl {

--- a/sshkey.h
+++ b/sshkey.h
@@ -164,7 +164,9 @@ struct sshkey_impl_funcs {
 	void (*cleanup)(struct sshkey *);	/* optional */
 	int (*equal)(const struct sshkey *, const struct sshkey *);
 	int (*serialize_public)(const struct sshkey *, struct sshbuf *,
-	    const char *, enum sshkey_serialize_rep);
+	    enum sshkey_serialize_rep);
+	int (*deserialize_public)(const char *, struct sshbuf *,
+	    struct sshkey *);
 	int (*generate)(struct sshkey *, int);	/* optional */
 	int (*copy_public)(const struct sshkey *, struct sshkey *);
 };
@@ -309,6 +311,10 @@ int	sshkey_sk_fields_equal(const struct sshkey *a, const struct sshkey *b);
 void	sshkey_sk_cleanup(struct sshkey *k);
 int	sshkey_serialize_sk(const struct sshkey *key, struct sshbuf *b);
 int	sshkey_copy_public_sk(const struct sshkey *from, struct sshkey *to);
+int	sshkey_deserialize_sk(struct sshbuf *b, struct sshkey *key);
+#ifdef WITH_OPENSSL
+int	check_rsa_length(const RSA *rsa); /* XXX remove */
+#endif
 
 int ssh_rsa_sign(const struct sshkey *key,
     u_char **sigp, size_t *lenp, const u_char *data, size_t datalen,

--- a/sshkey.h
+++ b/sshkey.h
@@ -169,6 +169,12 @@ struct sshkey_impl_funcs {
 	    struct sshkey *);
 	int (*generate)(struct sshkey *, int);	/* optional */
 	int (*copy_public)(const struct sshkey *, struct sshkey *);
+	int (*sign)(struct sshkey *, u_char **, size_t *,
+	    const u_char *, size_t, const char *,
+	    const char *, const char *, u_int); /* optional */
+	int (*verify)(const struct sshkey *, const u_char *, size_t,
+	    const u_char *, size_t, const char *, u_int,
+	    struct sshkey_sig_details **);
 };
 
 struct sshkey_impl {
@@ -315,41 +321,6 @@ int	sshkey_deserialize_sk(struct sshbuf *b, struct sshkey *key);
 #ifdef WITH_OPENSSL
 int	check_rsa_length(const RSA *rsa); /* XXX remove */
 #endif
-
-int ssh_rsa_sign(const struct sshkey *key,
-    u_char **sigp, size_t *lenp, const u_char *data, size_t datalen,
-    const char *ident);
-int ssh_rsa_verify(const struct sshkey *key,
-    const u_char *sig, size_t siglen, const u_char *data, size_t datalen,
-    const char *alg);
-int ssh_dss_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
-    const u_char *data, size_t datalen, u_int compat);
-int ssh_dss_verify(const struct sshkey *key,
-    const u_char *signature, size_t signaturelen,
-    const u_char *data, size_t datalen, u_int compat);
-int ssh_ecdsa_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
-    const u_char *data, size_t datalen, u_int compat);
-int ssh_ecdsa_verify(const struct sshkey *key,
-    const u_char *signature, size_t signaturelen,
-    const u_char *data, size_t datalen, u_int compat);
-int ssh_ecdsa_sk_verify(const struct sshkey *key,
-    const u_char *signature, size_t signaturelen,
-    const u_char *data, size_t datalen, u_int compat,
-    struct sshkey_sig_details **detailsp);
-int ssh_ed25519_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
-    const u_char *data, size_t datalen, u_int compat);
-int ssh_ed25519_verify(const struct sshkey *key,
-    const u_char *signature, size_t signaturelen,
-    const u_char *data, size_t datalen, u_int compat);
-int ssh_ed25519_sk_verify(const struct sshkey *key,
-    const u_char *signature, size_t signaturelen,
-    const u_char *data, size_t datalen, u_int compat,
-    struct sshkey_sig_details **detailsp);
-int ssh_xmss_sign(const struct sshkey *key, u_char **sigp, size_t *lenp,
-    const u_char *data, size_t datalen, u_int compat);
-int ssh_xmss_verify(const struct sshkey *key,
-    const u_char *signature, size_t signaturelen,
-    const u_char *data, size_t datalen, u_int compat);
 #endif
 
 #ifndef WITH_OPENSSL

--- a/sshkey.h
+++ b/sshkey.h
@@ -158,6 +158,24 @@ struct sshkey_sig_details {
 	uint8_t sk_flags;	/* U2F signature flags; see ssh-sk.h */
 };
 
+struct sshkey_impl_funcs {
+	u_int (*size)(const struct sshkey *);	/* optional */
+	int (*alloc)(struct sshkey *);		/* optional */
+	void (*cleanup)(struct sshkey *);	/* optional */
+};
+
+struct sshkey_impl {
+	const char *name;
+	const char *shortname;
+	const char *sigalg;
+	int type;
+	int nid;
+	int cert;
+	int sigonly;
+	int keybits;
+	const struct sshkey_impl_funcs *funcs;
+};
+
 struct sshkey	*sshkey_new(int);
 void		 sshkey_free(struct sshkey *);
 int		 sshkey_equal_public(const struct sshkey *,

--- a/sshkey.h
+++ b/sshkey.h
@@ -169,6 +169,8 @@ struct sshkey_impl_funcs {
 	    struct sshkey *);
 	int (*serialize_private)(const struct sshkey *, struct sshbuf *,
 	    enum sshkey_serialize_rep);
+	int (*deserialize_private)(const char *, struct sshbuf *,
+	    struct sshkey *);
 	int (*generate)(struct sshkey *, int);	/* optional */
 	int (*copy_public)(const struct sshkey *, struct sshkey *);
 	int (*sign)(struct sshkey *, u_char **, size_t *,
@@ -322,6 +324,7 @@ int	sshkey_copy_public_sk(const struct sshkey *from, struct sshkey *to);
 int	sshkey_deserialize_sk(struct sshbuf *b, struct sshkey *key);
 int	sshkey_serialize_private_sk(const struct sshkey *key,
     struct sshbuf *buf);
+int	sshkey_private_deserialize_sk(struct sshbuf *buf, struct sshkey *k);
 #ifdef WITH_OPENSSL
 int	check_rsa_length(const RSA *rsa); /* XXX remove */
 #endif

--- a/sshkey.h
+++ b/sshkey.h
@@ -162,6 +162,7 @@ struct sshkey_impl_funcs {
 	u_int (*size)(const struct sshkey *);	/* optional */
 	int (*alloc)(struct sshkey *);		/* optional */
 	void (*cleanup)(struct sshkey *);	/* optional */
+	int (*equal)(const struct sshkey *, const struct sshkey *);
 };
 
 struct sshkey_impl {
@@ -300,6 +301,9 @@ int	 sshkey_private_serialize_maxsign(struct sshkey *key,
 void	 sshkey_sig_details_free(struct sshkey_sig_details *);
 
 #ifdef SSHKEY_INTERNAL
+int	sshkey_sk_fields_equal(const struct sshkey *a, const struct sshkey *b);
+void	sshkey_sk_cleanup(struct sshkey *k);
+
 int ssh_rsa_sign(const struct sshkey *key,
     u_char **sigp, size_t *lenp, const u_char *data, size_t datalen,
     const char *ident);

--- a/sshkey.h
+++ b/sshkey.h
@@ -163,6 +163,8 @@ struct sshkey_impl_funcs {
 	int (*alloc)(struct sshkey *);		/* optional */
 	void (*cleanup)(struct sshkey *);	/* optional */
 	int (*equal)(const struct sshkey *, const struct sshkey *);
+	int (*serialize_public)(const struct sshkey *, struct sshbuf *,
+	    const char *, enum sshkey_serialize_rep);
 };
 
 struct sshkey_impl {
@@ -303,6 +305,7 @@ void	 sshkey_sig_details_free(struct sshkey_sig_details *);
 #ifdef SSHKEY_INTERNAL
 int	sshkey_sk_fields_equal(const struct sshkey *a, const struct sshkey *b);
 void	sshkey_sk_cleanup(struct sshkey *k);
+int	sshkey_serialize_sk(const struct sshkey *key, struct sshbuf *b);
 
 int ssh_rsa_sign(const struct sshkey *key,
     u_char **sigp, size_t *lenp, const u_char *data, size_t datalen,

--- a/sshkey.h
+++ b/sshkey.h
@@ -166,6 +166,7 @@ struct sshkey_impl_funcs {
 	int (*serialize_public)(const struct sshkey *, struct sshbuf *,
 	    const char *, enum sshkey_serialize_rep);
 	int (*generate)(struct sshkey *, int);	/* optional */
+	int (*copy_public)(const struct sshkey *, struct sshkey *);
 };
 
 struct sshkey_impl {
@@ -307,6 +308,7 @@ void	 sshkey_sig_details_free(struct sshkey_sig_details *);
 int	sshkey_sk_fields_equal(const struct sshkey *a, const struct sshkey *b);
 void	sshkey_sk_cleanup(struct sshkey *k);
 int	sshkey_serialize_sk(const struct sshkey *key, struct sshbuf *b);
+int	sshkey_copy_public_sk(const struct sshkey *from, struct sshkey *to);
 
 int ssh_rsa_sign(const struct sshkey *key,
     u_char **sigp, size_t *lenp, const u_char *data, size_t datalen,


### PR DESCRIPTION
This factors most of the algorithm-specific code from sshkey.c to the algorithm-specific files (e.g. ssh-rsa.c). There's probably more to do, like cleaning up the various ECDSA NID helpers, etc.