### PR TITLE
sftp: consistent "ls -l" user and group names

### DIFF
--- a/PROTOCOL
+++ b/PROTOCOL
@@ -635,6 +635,47 @@ This request is identical to the "home-directory" request documented in:
 
 https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-extensions-00#section-5
 
+4.12. sftp: Extension request "getusersgroups@openssh.com"
+
+This request asks the server to returns user and/or group names that
+correspond to one or more IDs (e.g. as returned from a SSH_FXP_STAT
+request). This may be used by the client to provide usernames in
+directory listings.
+
+	byte		SSH_FXP_EXTENDED
+	uint32		id
+	string		"getusersgroups@openssh.com"
+	string		uids
+	string		gids
+
+Where "uids" and "gids" consists of one or more integer user or group
+identifiers:
+
+	uint32		id-0
+	...
+
+The server will reply with a SSH_FXP_EXTENDED_REPLY:
+
+	byte		SSH_FXP_EXTENDED_REPLY
+	string		usernames
+	string		groupnames
+
+Where "username" and "groupnames" consists of names in identical request
+order to "uids" and "gids" respectively:
+
+	string		name-0
+	...
+
+If a name cannot be identified for a given user or group ID, an empty
+string will be returned in its place.
+
+It is acceptable for either "uids" or "gids" to be an empty set, in
+which case the respective "usernames" or "groupnames" list will also
+be empty.
+
+This extension is advertised in the SSH_FXP_VERSION hello with version
+"1".
+
 5. Miscellaneous changes
 
 5.1 Public key format

--- a/sftp-client.c
+++ b/sftp-client.c
@@ -84,6 +84,7 @@ struct sftp_conn {
 #define SFTP_EXT_LIMITS		0x00000040
 #define SFTP_EXT_PATH_EXPAND	0x00000080
 #define SFTP_EXT_COPY_DATA	0x00000100
+#define SFTP_EXT_GETUSERSGROUPS	0x00000200
 	u_int exts;
 	u_int64_t limit_kbps;
 	struct bwlimit bwlimit_in, bwlimit_out;
@@ -518,6 +519,10 @@ do_init(int fd_in, int fd_out, u_int transfer_buflen, u_int num_requests,
 		} else if (strcmp(name, "copy-data") == 0 &&
 		    strcmp((char *)value, "1") == 0) {
 			ret->exts |= SFTP_EXT_COPY_DATA;
+			known = 1;
+		} else if (strcmp(name, "getusersgroups@openssh.com") == 0 &&
+		    strcmp((char *)value, "1") == 0) {
+			ret->exts |= SFTP_EXT_GETUSERSGROUPS;
 			known = 1;
 		}
 		if (known) {
@@ -2725,6 +2730,119 @@ crossload_dir(struct sftp_conn *from, struct sftp_conn *to,
 	    dirattrib, preserve_flag, print_flag, follow_link_flag);
 	free(from_path_canon);
 	return ret;
+}
+
+int
+can_getusersgroups(struct sftp_conn *conn)
+{
+	return (conn->exts & SFTP_EXT_GETUSERSGROUPS) != 0;
+}
+
+int
+do_getusersgroups(struct sftp_conn *conn,
+    const u_int *uids, u_int nuids,
+    const u_int *gids, u_int ngids,
+    char ***usernamesp, char ***groupnamesp)
+{
+	struct sshbuf *msg, *uidbuf, *gidbuf;
+	u_int i, expected_id, id;
+	char *name, **usernames = NULL, **groupnames = NULL;
+	u_char type;
+	int r;
+
+	*usernamesp = *groupnamesp = NULL;
+	if (!can_getusersgroups(conn))
+		return SSH_ERR_FEATURE_UNSUPPORTED;
+
+	if ((msg = sshbuf_new()) == NULL ||
+	    (uidbuf = sshbuf_new()) == NULL ||
+	    (gidbuf = sshbuf_new()) == NULL)
+		fatal_f("sshbuf_new failed");
+	expected_id = id = conn->msg_id++;
+	debug2("Sending SSH2_FXP_EXTENDED(getusersgroups@openssh.com)");
+	for (i = 0; i < nuids; i++) {
+		if ((r = sshbuf_put_u32(uidbuf, uids[i])) != 0)
+			fatal_fr(r, "compose uids");
+	}
+	for (i = 0; i < ngids; i++) {
+		if ((r = sshbuf_put_u32(gidbuf, gids[i])) != 0)
+			fatal_fr(r, "compose gids");
+	}
+	if ((r = sshbuf_put_u8(msg, SSH2_FXP_EXTENDED)) != 0 ||
+	    (r = sshbuf_put_u32(msg, id)) != 0 ||
+	    (r = sshbuf_put_cstring(msg, "getusersgroups@openssh.com")) != 0 ||
+	    (r = sshbuf_put_stringb(msg, uidbuf)) != 0 ||
+	    (r = sshbuf_put_stringb(msg, gidbuf)) != 0)
+		fatal_fr(r, "compose");
+	send_msg(conn, msg);
+	get_msg(conn, msg);
+	if ((r = sshbuf_get_u8(msg, &type)) != 0 ||
+	    (r = sshbuf_get_u32(msg, &id)) != 0)
+		fatal_fr(r, "parse");
+	if (id != expected_id)
+		fatal("ID mismatch (%u != %u)", id, expected_id);
+	if (type == SSH2_FXP_STATUS) {
+		u_int status;
+		char *errmsg;
+
+		if ((r = sshbuf_get_u32(msg, &status)) != 0 ||
+		    (r = sshbuf_get_cstring(msg, &errmsg, NULL)) != 0)
+			fatal_fr(r, "parse status");
+		error("getusersgroups %s",
+		    *errmsg == '\0' ? fx2txt(status) : errmsg);
+		free(errmsg);
+		sshbuf_free(msg);
+		sshbuf_free(uidbuf);
+		sshbuf_free(gidbuf);
+		return -1;
+	} else if (type != SSH2_FXP_EXTENDED_REPLY)
+		fatal("Expected SSH2_FXP_EXTENDED_REPLY(%u) packet, got %u",
+		    SSH2_FXP_EXTENDED_REPLY, type);
+
+	/* reuse */
+	sshbuf_free(uidbuf);
+	sshbuf_free(gidbuf);
+	uidbuf = gidbuf = NULL;
+	if ((r = sshbuf_froms(msg, &uidbuf)) != 0 ||
+	    (r = sshbuf_froms(msg, &gidbuf)) != 0)
+		fatal_fr(r, "parse response");
+	if (nuids > 0) {
+		usernames = xcalloc(nuids, sizeof(*usernames));
+		for (i = 0; i < nuids; i++) {
+			if ((r = sshbuf_get_cstring(uidbuf, &name, NULL)) != 0)
+				fatal_fr(r, "parse user name");
+			/* Handle unresolved names */
+			if (*name == '\0') {
+				free(name);
+				name = NULL;
+			}
+			usernames[i] = name;
+		}
+	}
+	if (ngids > 0) {
+		groupnames = xcalloc(ngids, sizeof(*groupnames));
+		for (i = 0; i < ngids; i++) {
+			if ((r = sshbuf_get_cstring(gidbuf, &name, NULL)) != 0)
+				fatal_fr(r, "parse user name");
+			/* Handle unresolved names */
+			if (*name == '\0') {
+				free(name);
+				name = NULL;
+			}
+			groupnames[i] = name;
+		}
+	}
+	if (sshbuf_len(uidbuf) != 0)
+		fatal_f("unexpected extra username data");
+	if (sshbuf_len(gidbuf) != 0)
+		fatal_f("unexpected extra groupname data");
+	sshbuf_free(uidbuf);
+	sshbuf_free(gidbuf);
+	sshbuf_free(msg);
+	/* success */
+	*usernamesp = usernames;
+	*groupnamesp = groupnames;
+	return 0;
 }
 
 char *

--- a/sftp-client.h
+++ b/sftp-client.h
@@ -177,6 +177,15 @@ int crossload_dir(struct sftp_conn *from, struct sftp_conn *to,
     Attrib *dirattrib, int preserve_flag, int print_flag,
     int follow_link_flag);
 
+/*
+ * User/group ID to name translation.
+ */
+int can_getusersgroups(struct sftp_conn *conn);
+int do_getusersgroups(struct sftp_conn *conn,
+    const u_int *uids, u_int nuids,
+    const u_int *gids, u_int ngids,
+    char ***usernamesp, char ***groupnamesp);
+
 /* Concatenate paths, taking care of slashes. Caller must free result. */
 char *path_append(const char *, const char *);
 

--- a/sftp-common.c
+++ b/sftp-common.c
@@ -207,21 +207,25 @@ fx2txt(int status)
  * drwxr-xr-x    5 markus   markus       1024 Jan 13 18:39 .ssh
  */
 char *
-ls_file(const char *name, const struct stat *st, int remote, int si_units)
+ls_file(const char *name, const struct stat *st, int remote, int si_units,
+    const char *user, const char *group)
 {
 	int ulen, glen, sz = 0;
 	struct tm *ltime = localtime(&st->st_mtime);
-	const char *user, *group;
 	char buf[1024], lc[8], mode[11+1], tbuf[12+1], ubuf[11+1], gbuf[11+1];
 	char sbuf[FMT_SCALED_STRSIZE];
 	time_t now;
 
 	strmode(st->st_mode, mode);
 	if (remote) {
-		snprintf(ubuf, sizeof ubuf, "%u", (u_int)st->st_uid);
-		user = ubuf;
-		snprintf(gbuf, sizeof gbuf, "%u", (u_int)st->st_gid);
-		group = gbuf;
+		if (user == NULL) {
+			snprintf(ubuf, sizeof ubuf, "%u", (u_int)st->st_uid);
+			user = ubuf;
+		}
+		if (group == NULL) {
+			snprintf(gbuf, sizeof gbuf, "%u", (u_int)st->st_gid);
+			group = gbuf;
+		}
 		strlcpy(lc, "?", sizeof(lc));
 	} else {
 		user = user_from_uid(st->st_uid, 0);

--- a/sftp-common.h
+++ b/sftp-common.h
@@ -47,6 +47,7 @@ void	 stat_to_attrib(const struct stat *, Attrib *);
 void	 attrib_to_stat(const Attrib *, struct stat *);
 int	 decode_attrib(struct sshbuf *, Attrib *);
 int	 encode_attrib(struct sshbuf *, const Attrib *);
-char	*ls_file(const char *, const struct stat *, int, int);
+char	*ls_file(const char *, const struct stat *, int, int,
+    const char *, const char *);
 
 const char *fx2txt(int);

--- a/sftp-server.c
+++ b/sftp-server.c
@@ -1139,7 +1139,8 @@ process_readdir(u_int32_t id)
 				continue;
 			stat_to_attrib(&st, &(stats[count].attrib));
 			stats[count].name = xstrdup(dp->d_name);
-			stats[count].long_name = ls_file(dp->d_name, &st, 0, 0);
+			stats[count].long_name = ls_file(dp->d_name, &st,
+			    0, 0, NULL, NULL);
 			count++;
 			/* send up to 100 entries in one message */
 			/* XXX check packet size instead */

--- a/sftp-server.c
+++ b/sftp-server.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <pwd.h>
+#include <grp.h>
 #include <time.h>
 #include <unistd.h>
 #include <stdarg.h>
@@ -112,6 +113,7 @@ static void process_extended_limits(u_int32_t id);
 static void process_extended_expand(u_int32_t id);
 static void process_extended_copy_data(u_int32_t id);
 static void process_extended_home_directory(u_int32_t id);
+static void process_extended_getusersgroups(u_int32_t id);
 static void process_extended(u_int32_t id);
 
 struct sftp_handler {
@@ -160,6 +162,8 @@ static const struct sftp_handler extended_handlers[] = {
 	{ "copy-data", "copy-data", 0, process_extended_copy_data, 1 },
 	{ "home-directory", "home-directory", 0,
 	    process_extended_home_directory, 0 },
+	{ "getusersgroups", "getusersgroups@openssh.com", 0,
+	    process_extended_getusersgroups, 0 },
 	{ NULL, NULL, 0, NULL, 0 }
 };
 
@@ -718,6 +722,7 @@ process_init(void)
 	compose_extension(msg, "expand-path@openssh.com", "1");
 	compose_extension(msg, "copy-data", "1");
 	compose_extension(msg, "home-directory", "1");
+	compose_extension(msg, "getusersgroups@openssh.com", "1");
 
 	send_msg(msg);
 	sshbuf_free(msg);
@@ -1678,6 +1683,61 @@ process_extended_home_directory(u_int32_t id)
 	send_names(id, 1, &s);
  out:
 	free(username);
+}
+
+static void
+process_extended_getusersgroups(u_int32_t id)
+{
+	struct passwd *user_pw;
+	struct group *gr;
+	struct sshbuf *uids, *gids, *usernames, *groupnames, *msg;
+	int r;
+	u_int n, nusers = 0, ngroups = 0;
+	const char *name;
+
+	if ((usernames = sshbuf_new()) == NULL ||
+	    (groupnames = sshbuf_new()) == NULL ||
+	    (msg = sshbuf_new()) == NULL)
+		fatal_f("sshbuf_new failed");
+	if ((r = sshbuf_froms(iqueue, &uids)) != 0 ||
+	    (r = sshbuf_froms(iqueue, &gids)) != 0)
+		fatal_fr(r, "parse");
+	debug_f("uids len = %zu, gids len = %zu",
+	    sshbuf_len(uids), sshbuf_len(gids));
+	while (sshbuf_len(uids) != 0) {
+		if ((r = sshbuf_get_u32(uids, &n)) != 0)
+			fatal_fr(r, "parse inner uid");
+		user_pw = getpwuid((uid_t)n);
+		name = user_pw == NULL ? "" : user_pw->pw_name;
+		debug3_f("uid %u => \"%s\"", n, name);
+		if ((r = sshbuf_put_cstring(usernames, name)) != 0)
+			fatal_fr(r, "assemble gid reply");
+		nusers++;
+	}
+	while (sshbuf_len(gids) != 0) {
+		if ((r = sshbuf_get_u32(gids, &n)) != 0)
+			fatal_fr(r, "parse inner gid");
+		gr = getgrgid((gid_t)n);
+		name = gr == NULL ? "" : gr->gr_name;
+		debug3_f("gid %u => \"%s\"", n, name);
+		if ((r = sshbuf_put_cstring(groupnames, name)) != 0)
+			fatal_fr(r, "assemble gid reply");
+		nusers++;
+	}
+	verbose("getusersgroups: %u users, %u groups", nusers, ngroups);
+
+	if ((r = sshbuf_put_u8(msg, SSH2_FXP_EXTENDED_REPLY)) != 0 ||
+	    (r = sshbuf_put_u32(msg, id)) != 0 ||
+	    (r = sshbuf_put_stringb(msg, usernames)) != 0 ||
+	    (r = sshbuf_put_stringb(msg, groupnames)) != 0)
+		fatal_fr(r, "compose");
+	send_msg(msg);
+
+	sshbuf_free(uids);
+	sshbuf_free(gids);
+	sshbuf_free(usernames);
+	sshbuf_free(groupnames);
+	sshbuf_free(msg);
 }
 
 static void

--- a/sftp-usergroup.c
+++ b/sftp-usergroup.c
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2022 Damien Miller <djm@mindrot.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* sftp client user/group lookup and caching */
+
+#include <sys/types.h>
+#include <sys/tree.h>
+
+#include <glob.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+
+#include "log.h"
+#include "xmalloc.h"
+
+#include "sftp-common.h"
+#include "sftp-client.h"
+#include "sftp-usergroup.h"
+
+/* Tree of id, name */
+struct idname {
+        u_int id;
+	char *name;
+        RB_ENTRY(idname) entry;
+	/* XXX implement bounded cache as TAILQ */
+};
+static int
+idname_cmp(struct idname *a, struct idname *b)
+{
+	if (a->id == b->id)
+		return 0;
+	return a->id > b->id ? 1 : -1;
+}
+RB_HEAD(idname_tree, idname);
+RB_GENERATE_STATIC(idname_tree, idname, entry, idname_cmp)
+
+static struct idname_tree user_idname = RB_INITIALIZER(&user_idname);
+static struct idname_tree group_idname = RB_INITIALIZER(&group_idname);
+
+static void
+idname_free(struct idname *idname)
+{
+	if (idname == NULL)
+		return;
+	free(idname->name);
+	free(idname);
+}
+
+static void
+idname_enter(struct idname_tree *tree, u_int id, const char *name)
+{
+	struct idname *idname;
+
+	if ((idname = xcalloc(1, sizeof(*idname))) == NULL)
+		fatal_f("alloc");
+	idname->id = id;
+	idname->name = xstrdup(name);
+	if (RB_INSERT(idname_tree, tree, idname) != NULL)
+		idname_free(idname);
+}
+
+static const char *
+idname_lookup(struct idname_tree *tree, u_int id)
+{
+	struct idname idname, *found;
+
+	memset(&idname, 0, sizeof(idname));
+	idname.id = id;
+	if ((found = RB_FIND(idname_tree, tree, &idname)) != NULL)
+		return found->name;
+	return NULL;
+}
+
+static void
+freenames(char **names, u_int nnames)
+{
+	u_int i;
+
+	if (names == NULL)
+		return;
+	for (i = 0; i < nnames; i++)
+		free(names[i]);
+	free(names);
+}
+
+static void
+lookup_and_record(struct sftp_conn *conn,
+    u_int *uids, u_int nuids, u_int *gids, u_int ngids)
+{
+	int r;
+	u_int i;
+	char **usernames = NULL, **groupnames = NULL;
+
+	if ((r = do_getusersgroups(conn, uids, nuids, gids, ngids,
+	    &usernames, &groupnames)) != 0) {
+		debug_fr(r, "do_getusersgroups");
+		return;
+	}
+	for (i = 0; i < nuids; i++) {
+		if (usernames[i] == NULL) {
+			debug3_f("uid %u not resolved", uids[i]);
+			continue;
+		}
+		debug3_f("record uid %u => \"%s\"", uids[i], usernames[i]);
+		idname_enter(&user_idname, uids[i], usernames[i]);
+	}
+	for (i = 0; i < ngids; i++) {
+		if (groupnames[i] == NULL) {
+			debug3_f("gid %u not resolved", gids[i]);
+			continue;
+		}
+		debug3_f("record gid %u => \"%s\"", gids[i], groupnames[i]);
+		idname_enter(&group_idname, gids[i], groupnames[i]);
+	}
+	freenames(usernames, nuids);
+	freenames(groupnames, ngids);
+}
+
+static int
+has_id(u_int id, u_int *ids, u_int nids)
+{
+	u_int i;
+
+	if (nids == 0)
+		return 0;
+
+	/* XXX O(N^2) */
+	for (i = 0; i < nids; i++) {
+		if (ids[i] == id)
+			break;
+	}
+	return i < nids;
+}
+
+static void
+collect_ids_from_glob(glob_t *g, int user, u_int **idsp, u_int *nidsp)
+{
+	u_int id, i, n = 0, *ids = NULL;
+
+	for (i = 0; g->gl_pathv[i] != NULL; i++) {
+		if (user) {
+			if (ruser_name(g->gl_statv[i]->st_uid) != NULL)
+				continue; /* Already seen */
+			id = (u_int)g->gl_statv[i]->st_uid;
+		} else {
+			if (rgroup_name(g->gl_statv[i]->st_gid) != NULL)
+				continue; /* Already seen */
+			id = (u_int)g->gl_statv[i]->st_gid;
+		}
+		if (has_id(id, ids, n))
+			continue;
+		ids = xrecallocarray(ids, n, n + 1, sizeof(*ids));
+		ids[n++] = id;
+	}
+	*idsp = ids;
+	*nidsp = n;
+}
+
+void
+get_remote_user_groups_from_glob(struct sftp_conn *conn, glob_t *g)
+{
+	u_int *uids = NULL, nuids = 0, *gids = NULL, ngids = 0;
+
+	if (!can_getusersgroups(conn))
+		return;
+
+	collect_ids_from_glob(g, 1, &uids, &nuids);
+	collect_ids_from_glob(g, 0, &gids, &ngids);
+	lookup_and_record(conn, uids, nuids, gids, ngids);
+	free(uids);
+	free(gids);
+}
+
+static void
+collect_ids_from_dirents(SFTP_DIRENT **d, int user, u_int **idsp, u_int *nidsp)
+{
+	u_int id, i, n = 0, *ids = NULL;
+
+	for (i = 0; d[i] != NULL; i++) {
+		if (user) {
+			if (ruser_name((uid_t)(d[i]->a.uid)) != NULL)
+				continue; /* Already seen */
+			id = d[i]->a.uid;
+		} else {
+			if (rgroup_name((gid_t)(d[i]->a.gid)) != NULL)
+				continue; /* Already seen */
+			id = d[i]->a.gid;
+		}
+		if (has_id(id, ids, n))
+			continue;
+		ids = xrecallocarray(ids, n, n + 1, sizeof(*ids));
+		ids[n++] = id;
+	}
+	*idsp = ids;
+	*nidsp = n;
+}
+
+void
+get_remote_user_groups_from_dirents(struct sftp_conn *conn, SFTP_DIRENT **d)
+{
+	u_int *uids = NULL, nuids = 0, *gids = NULL, ngids = 0;
+
+	if (!can_getusersgroups(conn))
+		return;
+
+	collect_ids_from_dirents(d, 1, &uids, &nuids);
+	collect_ids_from_dirents(d, 0, &gids, &ngids);
+	lookup_and_record(conn, uids, nuids, gids, ngids);
+	free(uids);
+	free(gids);
+}
+
+const char *
+ruser_name(uid_t uid)
+{
+	return idname_lookup(&user_idname, (u_int)uid);
+}
+
+const char *
+rgroup_name(uid_t gid)
+{
+	return idname_lookup(&group_idname, (u_int)gid);
+}
+

--- a/sftp-usergroup.h
+++ b/sftp-usergroup.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 Damien Miller <djm@mindrot.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* sftp client user/group lookup and caching */
+
+/* Lookup uids/gids and populate cache */
+void get_remote_user_groups_from_glob(struct sftp_conn *conn, glob_t *g);
+void get_remote_user_groups_from_dirents(struct sftp_conn *conn, SFTP_DIRENT **d);
+
+/* Return user/group name from cache or NULL if not found */
+const char *ruser_name(uid_t uid);
+const char *rgroup_name(uid_t gid);

--- a/sftp.c
+++ b/sftp.c
@@ -49,6 +49,7 @@
 #include "sshbuf.h"
 #include "sftp-common.h"
 #include "sftp-client.h"
+#include "sftp-usergroup.h"
 
 /* File to read commands from */
 FILE* infile;
@@ -850,6 +851,7 @@ do_ls_dir(struct sftp_conn *conn, const char *path,
 		qsort(d, n, sizeof(*d), sdirent_comp);
 	}
 
+	get_remote_user_groups_from_dirents(conn, d);
 	for (n = 0; d[n] != NULL && !interrupted; n++) {
 		char *tmp, *fname;
 
@@ -861,14 +863,17 @@ do_ls_dir(struct sftp_conn *conn, const char *path,
 		free(tmp);
 
 		if (lflag & LS_LONG_VIEW) {
-			if (lflag & (LS_NUMERIC_VIEW|LS_SI_UNITS)) {
+			if ((lflag & (LS_NUMERIC_VIEW|LS_SI_UNITS)) != 0 ||
+			    can_getusersgroups(conn)) {
 				char *lname;
 				struct stat sb;
 
 				memset(&sb, 0, sizeof(sb));
 				attrib_to_stat(&d[n]->a, &sb);
 				lname = ls_file(fname, &sb, 1,
-				    (lflag & LS_SI_UNITS), NULL, NULL);
+				    (lflag & LS_SI_UNITS),
+				    ruser_name(sb.st_uid),
+				    rgroup_name(sb.st_gid));
 				mprintf("%s\n", lname);
 				free(lname);
 			} else
@@ -990,6 +995,7 @@ do_globbed_ls(struct sftp_conn *conn, const char *path,
 		sort_glob = NULL;
 	}
 
+	get_remote_user_groups_from_glob(conn, &g);
 	for (j = 0; j < nentries && !interrupted; j++) {
 		i = indices[j];
 		fname = path_strip(g.gl_pathv[i], strip_path);
@@ -999,7 +1005,9 @@ do_globbed_ls(struct sftp_conn *conn, const char *path,
 				continue;
 			}
 			lname = ls_file(fname, g.gl_statv[i], 1,
-			    (lflag & LS_SI_UNITS), NULL, NULL);
+			    (lflag & LS_SI_UNITS),
+			    ruser_name(g.gl_statv[i]->st_uid),
+			    rgroup_name(g.gl_statv[i]->st_gid));
 			mprintf("%s\n", lname);
 			free(lname);
 		} else {

--- a/sftp.c
+++ b/sftp.c
@@ -868,7 +868,7 @@ do_ls_dir(struct sftp_conn *conn, const char *path,
 				memset(&sb, 0, sizeof(sb));
 				attrib_to_stat(&d[n]->a, &sb);
 				lname = ls_file(fname, &sb, 1,
-				    (lflag & LS_SI_UNITS));
+				    (lflag & LS_SI_UNITS), NULL, NULL);
 				mprintf("%s\n", lname);
 				free(lname);
 			} else
@@ -999,7 +999,7 @@ do_globbed_ls(struct sftp_conn *conn, const char *path,
 				continue;
 			}
 			lname = ls_file(fname, g.gl_statv[i], 1,
-			    (lflag & LS_SI_UNITS));
+			    (lflag & LS_SI_UNITS), NULL, NULL);
 			mprintf("%s\n", lname);
 			free(lname);
 		} else {

--- a/sftp/Makefile
+++ b/sftp/Makefile
@@ -2,7 +2,7 @@
 
 .PATH:		${.CURDIR}/..
 
-SRCS=	sftp.c sftp-client.c sftp-common.c sftp-glob.c
+SRCS=	sftp.c sftp-client.c sftp-common.c sftp-glob.c sftp-usergroup.c
 SRCS+=	atomicio.c cleanup.c fatal.c progressmeter.c utf8.c
 SRCS+=	${SRCS_BASE}
 


### PR DESCRIPTION
This implements protocol extensions for resolving uid => username and gid => group name in `sftp` and `sftp-server`, and uses these to populate `ls -l` directory listings.

This is all @daztucker's fault.