### PR TITLE
Allow separate SSH_ASKPASS_REQUIRE control for reading passphrases and sending notifications

### DIFF
--- a/readpass.c
+++ b/readpass.c
@@ -107,6 +107,35 @@ ssh_askpass(char *askpass, const char *msg, const char *env_hint)
 	return pass;
 }
 
+#define FORCE_NONE	0
+#define FORCE_PREFER	1
+#define FORCE_FORCE	2
+#define FORCE_NEVER	3
+
+/*
+ * Check $SSH_ASKPASS_REQUIRE for the given context (askpass or notify),
+ * returns one of the FORCE_* values.
+ */
+static int
+check_forced(int is_notify)
+{
+	const char *s;
+
+	if ((s = getenv(SSH_ASKPASS_REQUIRE_ENV)) == NULL)
+		return FORCE_NONE;
+
+	if (strcasecmp(s, "force") == 0 ||
+	    strstr(s, is_notify ? "notify:force" : "askpass:force"))
+		return FORCE_FORCE;
+	if (strcasecmp(s, "never") == 0 ||
+	    strstr(s, is_notify ? "notify:never" : "askpass:never"))
+		return FORCE_NEVER;
+	if (strcasecmp(s, "prefer") == 0 ||
+	    strstr(s, is_notify ? "notify:prefer" : "askpass:prefer"))
+		return FORCE_PREFER;
+	return FORCE_NONE;
+}
+
 /* private/internal read_passphrase flags */
 #define RP_ASK_PERMISSION	0x8000 /* pass hint to askpass for confirm UI */
 
@@ -126,14 +155,18 @@ read_passphrase(const char *prompt, int flags)
 
 	if ((s = getenv("DISPLAY")) != NULL)
 		allow_askpass = *s != '\0';
-	if ((s = getenv(SSH_ASKPASS_REQUIRE_ENV)) != NULL) {
-		if (strcasecmp(s, "force") == 0) {
-			use_askpass = 1;
-			allow_askpass = 1;
-		} else if (strcasecmp(s, "prefer") == 0)
-			use_askpass = allow_askpass;
-		else if (strcasecmp(s, "never") == 0)
-			allow_askpass = 0;
+
+	switch (check_forced(0)) {
+	case FORCE_PREFER:
+		use_askpass = allow_askpass;
+		break;
+	case FORCE_FORCE:
+		use_askpass = 1;
+		allow_askpass = 1;
+		break;
+	case FORCE_NEVER:
+		allow_askpass = 0;
+		break;
 	}
 
 	rppflags = (flags & RP_ECHO) ? RPP_ECHO_ON : RPP_ECHO_OFF;
@@ -241,29 +274,49 @@ notify_start(int force_askpass, const char *fmt, ...)
 	void (*osigchld)(int) = NULL;
 	const char *askpass, *s;
 	struct notifier_ctx *ret = NULL;
+	int have_display = 0, use_askpass = 0;
 
 	va_start(args, fmt);
 	xvasprintf(&prompt, fmt, args);
 	va_end(args);
 
-	if (fflush(NULL) != 0)
-		error_f("fflush: %s", strerror(errno));
-	if (!force_askpass && isatty(STDERR_FILENO)) {
-		writemsg(prompt);
-		goto out_ctx;
-	}
+	if ((s = getenv("DISPLAY")) != NULL)
+		have_display = *s != '\0';
 	if ((askpass = getenv("SSH_ASKPASS")) == NULL)
 		askpass = _PATH_SSH_ASKPASS_DEFAULT;
-	if (*askpass == '\0') {
+	if (*askpass == '\0')
+		askpass = NULL;
+
+	switch (check_forced(1)) {
+	case FORCE_PREFER:
+		use_askpass = have_display && askpass != NULL;
+		break;
+	case FORCE_FORCE:
+		use_askpass = 1;
+		break;
+	case FORCE_NEVER:
+		use_askpass = 0;
+		break;
+	}
+	use_askpass |= force_askpass;
+	if (use_askpass && askpass == NULL) {
 		debug3_f("cannot notify: no askpass");
 		goto out;
 	}
-	if (getenv("DISPLAY") == NULL &&
-	    ((s = getenv(SSH_ASKPASS_REQUIRE_ENV)) == NULL ||
-	    strcmp(s, "force") != 0)) {
-		debug3_f("cannot notify: no display");
-		goto out;
+
+	if (fflush(NULL) != 0)
+		error_f("fflush: %s", strerror(errno));
+	if (!use_askpass) {
+		if (isatty(STDERR_FILENO)) {
+			writemsg(prompt);
+			goto out_ctx;
+		}
+		if (!have_display || askpass == NULL) {
+			debug3_f("cannot notify: no askpass/display");
+			goto out;
+		}
 	}
+	/* using askpass */
 	osigchld = ssh_signal(SIGCHLD, SIG_DFL);
 	if ((pid = fork()) == -1) {
 		error_f("fork: %s", strerror(errno));

--- a/readpass.c
+++ b/readpass.c
@@ -282,7 +282,8 @@ notify_start(int force_askpass, const char *fmt, ...)
 
 	if ((s = getenv("DISPLAY")) != NULL)
 		have_display = *s != '\0';
-	if ((askpass = getenv("SSH_ASKPASS")) == NULL)
+	askpass = getenv(SSH_ASKPASS_NOTIFY_ENV);
+	if (askpass == NULL && (askpass = getenv(SSH_ASKPASS_ENV)) == NULL)
 		askpass = _PATH_SSH_ASKPASS_DEFAULT;
 	if (*askpass == '\0')
 		askpass = NULL;

--- a/ssh.1
+++ b/ssh.1
@@ -99,7 +99,8 @@ A complete command line may be specified as
 .Ar command ,
 or it may have additional arguments.
 If supplied, the arguments will be appended to the command, separated by
-spaces, before it is sent to the server to be executed.
+spaces, before it is sent to the server to be executed, using the remote
+user's shell.
 .Pp
 The options are as follows:
 .Pp
@@ -1444,8 +1445,10 @@ or related script.
 may be necessary to redirect the input from
 .Pa /dev/null
 to make this work.)
+This program may also be used for some notifications for the user, including
+situations where they are required to touch a FIDO token.
 .It Ev SSH_ASKPASS_REQUIRE
-Allows further control over the use of an askpass program.
+Allows further control over the use of the askpass program.
 If this variable is set to
 .Dq never
 then
@@ -1463,6 +1466,19 @@ then the askpass program will be used for all passphrase input regardless
 of whether
 .Ev DISPLAY
 is set.
+.Pp
+It is possible to control the use of the askpass program for requesting
+passphrases and issuing notifications separately by prefixing the above
+keywords with either
+.Dq askpass:
+or
+.Dq notify: .
+For example, a
+.Ev SSH_ASKPASS_REQUIRE
+value of
+.Dq askpass:force notify:never
+would require the use of the askpass program for requesting passphrases but
+disable it for notifications.
 .It Ev SSH_AUTH_SOCK
 Identifies the path of a
 .Ux Ns -domain

--- a/ssh.1
+++ b/ssh.1
@@ -1447,6 +1447,13 @@ may be necessary to redirect the input from
 to make this work.)
 This program may also be used for some notifications for the user, including
 situations where they are required to touch a FIDO token.
+.It Ev SSH_ASKPASS_NOTIFY
+Specifies a program to be used instead of the default askpass program (or any
+one set via
+.Ev SSH_ASKPASS )
+that is used only for displaying notifications to the user, and not for
+requesting passphrases.
+By default, the same askpass program is used for both cases.
 .It Ev SSH_ASKPASS_REQUIRE
 Allows further control over the use of the askpass program.
 If this variable is set to

--- a/ssh.h
+++ b/ssh.h
@@ -68,6 +68,11 @@
 #define SSH_ASKPASS_ENV		"SSH_ASKPASS"
 
 /*
+ * Environment variable to set an askpass that is used for notifications only.
+ */
+#define SSH_ASKPASS_NOTIFY_ENV	"SSH_ASKPASS_NOTIFY"
+
+/*
  * Environment variable to control whether or not askpass is used.
  */
 #define SSH_ASKPASS_REQUIRE_ENV		"SSH_ASKPASS_REQUIRE"


### PR DESCRIPTION
This finesses the askpass behavior by providing more granulat controls over the askpass program for the two purposes that OpenSSH uses it (reading passphrases vs sending asynchronous notifications).

It extends the `SSH_ASKPASS_REQUIRE` environment variable to allow separate forcing/disallowal of the askpass for each of these cases, e.g. `SSH_ASKPASS_REQUIRE=readpass:force notify:never`

It also adds a new `SSH_ASKPASS_NOTIFY` environment variable that allows use of a separate binary for notifications.