### PR TITLE
Improve OpenSSH performance on high bandwidth x delay links

### DIFF
--- a/channels.c
+++ b/channels.c
@@ -78,6 +78,7 @@
 #include "authfd.h"
 #include "pathnames.h"
 #include "match.h"
+#include "kex.h"
 
 /* XXX remove once we're satisfied there's no lurking bugs */
 /* #define DEBUG_CHANNEL_POLL 1 */
@@ -926,6 +927,23 @@ channel_still_open(struct ssh *ssh)
 		}
 	}
 	return 0;
+}
+
+
+static u_int
+channel_count_open(struct ssh *ssh)
+{
+	u_int i, n;
+	Channel *c;
+
+	for (i = n = 0; i < ssh->chanctxt->channels_alloc; i++) {
+		if ((c = ssh->chanctxt->channels[i]) == NULL ||
+		    c->type != SSH_CHANNEL_OPEN ||
+		    c->flags & (CHAN_CLOSE_SENT|CHAN_CLOSE_RCVD))
+			continue;
+		n++;
+	}
+	return n;
 }
 
 /* Returns true if a channel with a TTY is open. */
@@ -2336,12 +2354,79 @@ channel_check_window(struct ssh *ssh, Channel *c)
 		    (r = sshpkt_send(ssh)) != 0) {
 			fatal_fr(r, "channel %i", c->self);
 		}
-		debug2("channel %d: window %d sent adjust %d", c->self,
+		debug3_f("channel %d: window %d sent adjust %d", c->self,
 		    c->local_window, c->local_consumed);
 		c->local_window += c->local_consumed;
 		c->local_consumed = 0;
 	}
 	return 1;
+}
+
+/*
+ * Try to update local_window_max when the TCP receive window grows,
+ * if the peer supports the channel-window-max@openssh.com extension.
+ * NB. must be called before channel_check_window(), as that clobbers
+ * c->local_consumed.
+ */
+static void
+channel_check_max_window(struct ssh *ssh, Channel *c)
+{
+	int r, tcp_rwin;
+	u_int new_window_max;
+
+	if ((ssh->kex->flags & KEX_HAS_CHANNEL_MAX_WINDOW) == 0)
+		return; /* no protocol extension support */
+	if (c->local_consumed == 0)
+		return; /* only modify window for active channels */
+	if (c->type != SSH_CHANNEL_OPEN ||
+	    (c->flags & (CHAN_CLOSE_SENT|CHAN_CLOSE_RCVD)) != 0)
+		return; /* channel not in open state */
+	if ((tcp_rwin = ssh_packet_get_tcp_rwin(ssh)) == -1)
+		return; /* no TCP window recorded */
+	if (c->local_window_max >= sshbuf_max_size(c->output))
+		return; /* Already at max */
+
+	/*
+	 * XXX the following rules are all heuristics with factors that
+	 * I just made up - djm
+	 * XXX this increases the SSH window to the TCP window in
+	 * one shot. Is this what we want? Alternately we could
+	 * increase by a fraction of the difference, so the SSH window
+	 * successively approximates the TCP window.
+	 * XXX there is only a naive fair-share the TCP window across
+	 * channel windows. It treats all channel identically (e.g. an
+	 * agent connection vs a shell) and doesn't try very hard to only
+	 * increase the window for channels that need it.
+	 * XXX maybe maintain a notion of "claimed TCP window" and
+	 * give it out only to channels that are active?
+	 * XXX regardless, a bit of oversubscription of the TCP window
+	 * is probably desirable as it's likely that not all channels will
+	 * be fully utilising their windows simultaneously.
+	 * XXX this never shrinks the window. This might be desirable for
+	 * idle channels if other are busy, but would be a fair bit of work.
+	 */
+	if (sshbuf_len(c->output) > c->local_window_max / 4)
+		return; /* Don't increase window if output is slow/filling */
+
+	/* Allow some oversubscription of the TCP window across channels */
+	new_window_max = (3 * (u_int)tcp_rwin) / channel_count_open(ssh);
+	if (new_window_max > (u_int)tcp_rwin)
+		new_window_max = (u_int)tcp_rwin;
+	if (new_window_max > sshbuf_max_size(c->output))
+		new_window_max = sshbuf_max_size(c->output);
+
+	if (new_window_max <= c->local_window_max)
+		return; /* don't shrink */
+
+	channel_request_start(ssh, c->self,
+	    "max-window@openssh.com", 0);
+	if ((r = sshpkt_put_u32(ssh, new_window_max)) != 0 ||
+	    (r = sshpkt_send(ssh)) != 0)
+		fatal_fr(r, "channel %i", c->self);
+	debug2_f("channel %d: sent max-window@openssh.com "
+	    "%d -> %d (+%d), peer TCP rwin %d", c->self, c->local_window_max,
+	    new_window_max, new_window_max - c->local_window_max, tcp_rwin);
+	c->local_window_max = new_window_max;
 }
 
 static void
@@ -2350,6 +2435,7 @@ channel_post_open(struct ssh *ssh, Channel *c)
 	channel_handle_rfd(ssh, c);
 	channel_handle_wfd(ssh, c);
 	channel_handle_efd(ssh, c);
+	channel_check_max_window(ssh, c);
 	channel_check_window(ssh, c);
 }
 
@@ -3548,7 +3634,7 @@ channel_input_open_confirmation(int type, u_int32_t seq, struct ssh *ssh)
 	}
 
 	c->have_remote_id = 1;
-	c->remote_window = remote_window;
+	c->remote_window = c->remote_window_max = remote_window;
 	c->remote_maxpacket = remote_maxpacket;
 	c->type = SSH_CHANNEL_OPEN;
 	if (c->open_confirm) {
@@ -3616,6 +3702,53 @@ channel_input_open_failure(int type, u_int32_t seq, struct ssh *ssh)
 }
 
 int
+channel_input_max_window(struct ssh *ssh, Channel *c)
+{
+	u_int old_window, new_max_window;
+	int r;
+
+	if (c->type != SSH_CHANNEL_OPEN) {
+		debug_f("channel %d: not open", c->self);
+		return SSH_ERR_INVALID_ARGUMENT;
+	}
+	if ((r = sshpkt_get_u32(ssh, &new_max_window)) != 0 ||
+	    (r = sshpkt_get_end(ssh)) != 0) {
+		error_fr(r, "channel %d: parse", c->self);
+		return r;
+	}
+	old_window = c->remote_window;
+	if (new_max_window > c->remote_window_max) {
+		/* Usual case: remote grows max window */
+		c->remote_window += new_max_window - c->remote_window_max;
+	} else if (new_max_window < c->remote_window_max) {
+		/*
+		 * Only allow shrinking the window if there is
+		 * sufficient capacity to do so.
+		 */
+		if (c->remote_window_max - new_max_window > c->remote_window) {
+			error_f("channel %d: remote requested invalid remote "
+			    "window size", c->self);
+			/* XXX what to do? close chan? set remote_window=0? */
+			/* XXX could gracefully ratchet window back */
+			/* XXX maybe better to just ban shrinking? */
+			return SSH_ERR_INVALID_ARGUMENT;
+		}
+		c->remote_window -= c->remote_window_max - new_max_window;
+	} else {
+		/* Same size shouldn't happen */
+		debug_f("channel %d: useless max-window update", c->self);
+	}
+	debug2_f("channel %d: new remote window max %d -> %d (%+d)",
+	    c->self, c->remote_window_max, new_max_window,
+	    new_max_window - c->remote_window_max);
+	debug3_f("channel %d: implicit window adjust %d -> %d (%+d)",
+	    c->self, old_window, c->remote_window,
+	    c->remote_window - old_window);
+	c->remote_window_max = new_max_window;
+	return 0;
+}
+
+int
 channel_input_window_adjust(int type, u_int32_t seq, struct ssh *ssh)
 {
 	int id = channel_parse_id(ssh, __func__, "window adjust");
@@ -3636,11 +3769,12 @@ channel_input_window_adjust(int type, u_int32_t seq, struct ssh *ssh)
 		error_fr(r, "parse adjust");
 		ssh_packet_disconnect(ssh, "Invalid window adjust message");
 	}
-	debug2("channel %d: rcvd adjust %u", c->self, adjust);
 	if ((new_rwin = c->remote_window + adjust) < c->remote_window) {
 		fatal("channel %d: adjust %u overflows remote window %u",
 		    c->self, adjust, c->remote_window);
 	}
+	debug3_f("channel %d: rcvd adjust %u window %u/%u", c->self, adjust,
+	    c->remote_window, c->remote_window_max);
 	c->remote_window = new_rwin;
 	return 0;
 }

--- a/channels.h
+++ b/channels.h
@@ -165,6 +165,7 @@ struct Channel {
 	char   *remote_name;	/* remote hostname */
 
 	u_int	remote_window;
+	u_int	remote_window_max;
 	u_int	remote_maxpacket;
 	u_int	local_window;
 	u_int	local_window_exceeded;
@@ -325,6 +326,7 @@ int	 channel_input_open_failure(int, u_int32_t, struct ssh *);
 int	 channel_input_port_open(int, u_int32_t, struct ssh *);
 int	 channel_input_window_adjust(int, u_int32_t, struct ssh *);
 int	 channel_input_status_confirm(int, u_int32_t, struct ssh *);
+int	 channel_input_max_window(struct ssh *ssh, Channel *c);
 
 /* file descriptor handling (read/write) */
 struct pollfd;

--- a/clientloop.c
+++ b/clientloop.c
@@ -1979,6 +1979,9 @@ client_input_channel_req(int type, u_int32_t seq, struct ssh *ssh)
 		if ((r = sshpkt_get_end(ssh)) != 0)
 			goto out;
 		chan_rcvd_eow(ssh, c);
+	} else if (strcmp(rtype, "max-window@openssh.com") == 0) {
+		if ((r = channel_input_max_window(ssh, c)) == 0)
+			success = 1;
 	} else if (strcmp(rtype, "exit-status") == 0) {
 		if ((r = sshpkt_get_u32(ssh, &exitval)) != 0)
 			goto out;

--- a/kex.c
+++ b/kex.c
@@ -534,13 +534,16 @@ kex_compose_ext_info_server(struct ssh *ssh, struct sshbuf *m)
 	if (ssh->kex->server_sig_algs == NULL &&
 	    (ssh->kex->server_sig_algs = sshkey_alg_list(0, 1, 1, ',')) == NULL)
 		return SSH_ERR_ALLOC_FAIL;
-	if ((r = sshbuf_put_u32(m, 3)) != 0 ||
+	if ((r = sshbuf_put_u32(m, 4)) != 0 ||
 	    (r = sshbuf_put_cstring(m, "server-sig-algs")) != 0 ||
 	    (r = sshbuf_put_cstring(m, ssh->kex->server_sig_algs)) != 0 ||
 	    (r = sshbuf_put_cstring(m,
 	    "publickey-hostbound@openssh.com")) != 0 ||
 	    (r = sshbuf_put_cstring(m, "0")) != 0 ||
 	    (r = sshbuf_put_cstring(m, "ping@openssh.com")) != 0 ||
+	    (r = sshbuf_put_cstring(m, "0")) != 0 ||
+	    (r = sshbuf_put_cstring(m,
+	    "channel-max-window@openssh.com")) != 0 ||
 	    (r = sshbuf_put_cstring(m, "0")) != 0) {
 		error_fr(r, "compose");
 		return r;
@@ -553,8 +556,11 @@ kex_compose_ext_info_client(struct ssh *ssh, struct sshbuf *m)
 {
 	int r;
 
-	if ((r = sshbuf_put_u32(m, 1)) != 0 ||
+	if ((r = sshbuf_put_u32(m, 2)) != 0 ||
 	    (r = sshbuf_put_cstring(m, "ext-info-in-auth@openssh.com")) != 0 ||
+	    (r = sshbuf_put_cstring(m, "0")) != 0 ||
+	    (r = sshbuf_put_cstring(m,
+	    "channel-max-window@openssh.com")) != 0 ||
 	    (r = sshbuf_put_cstring(m, "0")) != 0) {
 		error_fr(r, "compose");
 		goto out;
@@ -684,6 +690,11 @@ kex_ext_info_client_parse(struct ssh *ssh, const char *name,
 		    "0", KEX_HAS_PING)) != 0) {
 			return r;
 		}
+	} else if (strcmp(name, "channel-max-window@openssh.com") == 0) {
+		if ((r = kex_ext_info_check_ver(ssh->kex, name, value, vlen,
+		    "0", KEX_HAS_CHANNEL_MAX_WINDOW)) != 0) {
+			return r;
+		}
 	} else
 		debug_f("%s (unrecognised)", name);
 
@@ -699,6 +710,11 @@ kex_ext_info_server_parse(struct ssh *ssh, const char *name,
 	if (strcmp(name, "ext-info-in-auth@openssh.com") == 0) {
 		if ((r = kex_ext_info_check_ver(ssh->kex, name, value, vlen,
 		    "0", KEX_HAS_EXT_INFO_IN_AUTH)) != 0) {
+			return r;
+		}
+	} else if (strcmp(name, "channel-max-window@openssh.com") == 0) {
+		if ((r = kex_ext_info_check_ver(ssh->kex, name, value, vlen,
+		    "0", KEX_HAS_CHANNEL_MAX_WINDOW)) != 0) {
 			return r;
 		}
 	} else

--- a/kex.h
+++ b/kex.h
@@ -106,6 +106,7 @@ enum kex_exchange {
 #define KEX_RSA_SHA2_512_SUPPORTED	0x0010 /* only set in server for now */
 #define KEX_HAS_PING			0x0020
 #define KEX_HAS_EXT_INFO_IN_AUTH	0x0040
+#define KEX_HAS_CHANNEL_MAX_WINDOW	0x0080
 
 struct sshenc {
 	char	*name;

--- a/packet.c
+++ b/packet.c
@@ -199,6 +199,9 @@ struct session_state {
 	/* One-off warning about weak ciphers */
 	int cipher_warning_done;
 
+	/* Last observed TCP receive window size */
+	int tcp_rwin;
+
 	/* Hook for fuzzing inbound packets */
 	ssh_packet_hook_fn *hook_in;
 	void *hook_in_ctx;
@@ -228,6 +231,7 @@ ssh_alloc_session_state(void)
 	state->max_packet_size = 32768;
 	state->packet_timeout_ms = -1;
 	state->p_send.packets = state->p_read.packets = 0;
+	state->tcp_rwin = -1;
 	state->initialized = 1;
 	/*
 	 * ssh_packet_send2() needs to queue packets until
@@ -554,6 +558,37 @@ ssh_packet_rdomain_in(struct ssh *ssh)
 		return NULL;
 	ssh->rdomain_in = get_rdomain(ssh->state->connection_in);
 	return ssh->rdomain_in;
+}
+
+static void
+ssh_packet_update_tcp_rwin(struct ssh *ssh)
+{
+	int rwin;
+	socklen_t len = sizeof(rwin);
+
+	if (ssh->state == NULL ||
+	    !ssh_packet_connection_is_on_socket(ssh))
+		return;
+	if (getsockopt(ssh->state->connection_in, SOL_SOCKET, SO_RCVBUF,
+	    &rwin, &len) != 0) {
+		debug_f("getsockopt(%d SO_RCVBUF): %s",
+		    ssh->state->connection_in, strerror(errno));
+		return;
+	}
+	if (ssh->state->tcp_rwin != -1 && rwin != ssh->state->tcp_rwin) {
+		debug3_f("TCP receive window %d -> %d (%+d)",
+		    ssh->state->tcp_rwin, rwin, rwin - ssh->state->tcp_rwin);
+	}
+	ssh->state->tcp_rwin = rwin;
+}
+
+int
+ssh_packet_get_tcp_rwin(struct ssh *ssh)
+{
+	if (ssh == NULL || ssh->state == NULL ||
+	    !ssh_packet_connection_is_on_socket(ssh))
+		return -1;
+	return ssh->state->tcp_rwin;
 }
 
 /* Closes the connection and clears and frees internal data structures. */
@@ -1388,6 +1423,8 @@ ssh_packet_read_seqnr(struct ssh *ssh, u_char *typep, u_int32_t *seqnr_p)
 		/* Append it to the buffer. */
 		if ((r = ssh_packet_process_incoming(ssh, buf, len)) != 0)
 			goto out;
+
+		ssh_packet_update_tcp_rwin(ssh);
 	}
  out:
 	return r;
@@ -1804,6 +1841,7 @@ ssh_packet_process_read(struct ssh *ssh, int fd)
 
 	if ((r = sshbuf_read(fd, state->input, PACKET_MAX_SIZE, &rlen)) != 0)
 		return r;
+	ssh_packet_update_tcp_rwin(ssh);
 
 	if (state->packet_discard) {
 		if ((r = sshbuf_consume_end(state->input, rlen)) != 0)

--- a/packet.h
+++ b/packet.h
@@ -159,6 +159,7 @@ int	 ssh_remote_port(struct ssh *);
 const char *ssh_local_ipaddr(struct ssh *);
 int	 ssh_local_port(struct ssh *);
 const char *ssh_packet_rdomain_in(struct ssh *);
+int	 ssh_packet_get_tcp_rwin(struct ssh *);
 
 void	 ssh_packet_set_rekey_limits(struct ssh *, u_int64_t, u_int32_t);
 time_t	 ssh_packet_get_rekey_timeout(struct ssh *);

--- a/serverloop.c
+++ b/serverloop.c
@@ -880,6 +880,9 @@ server_input_channel_req(int type, u_int32_t seq, struct ssh *ssh)
 		if ((r = sshpkt_get_end(ssh)) != 0)
 			sshpkt_fatal(ssh, r, "%s: parse packet", __func__);
 		chan_rcvd_eow(ssh, c);
+	} else if (strcmp(rtype, "max-window@openssh.com") == 0) {
+		if ((r = channel_input_max_window(ssh, c)) == 0)
+			success = 1;
 	} else if ((c->type == SSH_CHANNEL_LARVAL ||
 	    c->type == SSH_CHANNEL_OPEN) && strcmp(c->ctype, "session") == 0)
 		success = session_input_channel_req(ssh, c, rtype);


### PR DESCRIPTION
The SSH protocol performs flow control using a channel receive window that may only be set at the time a channel is created and cannot be subsequently modified.

The current default window size is sufficient for most uses, but on high bandwidth x delay links it is not enough. Increasing the default window size is possible, but carries the cost of additional worst-case memory usage if the output side is slow.

This implements a protocol extension to vary the maximum channel window after the channel has been created, and uses this extension to grow the window if the TCP receive window increases in size. TCP has had a half-century of optimisation, so we should copy its homework wherever possible.

This is based on work by Denzel Strauss and Sally Sun during their STEP iternship at Google.