### PR TITLE
Separate PerSourcePenalties IPv4 and IPv6 tables

### DIFF
--- a/servconf.c
+++ b/servconf.c
@@ -147,8 +147,10 @@ initialize_server_options(ServerOptions *options)
 	options->per_source_masklen_ipv6 = -1;
 	options->per_source_penalty_exempt = NULL;
 	options->per_source_penalty.enabled = -1;
-	options->per_source_penalty.max_sources = -1;
+	options->per_source_penalty.max_sources4 = -1;
+	options->per_source_penalty.max_sources6 = -1;
 	options->per_source_penalty.overflow_mode = -1;
+	options->per_source_penalty.overflow_mode6 = -1;
 	options->per_source_penalty.penalty_crash = -1;
 	options->per_source_penalty.penalty_authfail = -1;
 	options->per_source_penalty.penalty_noauth = -1;
@@ -389,10 +391,14 @@ fill_default_server_options(ServerOptions *options)
 		options->per_source_masklen_ipv6 = 128;
 	if (options->per_source_penalty.enabled == -1)
 		options->per_source_penalty.enabled = 1;
-	if (options->per_source_penalty.max_sources == -1)
-		options->per_source_penalty.max_sources = 65536;
+	if (options->per_source_penalty.max_sources4 == -1)
+		options->per_source_penalty.max_sources4 = 65536;
+	if (options->per_source_penalty.max_sources6 == -1)
+		options->per_source_penalty.max_sources6 = 65536;
 	if (options->per_source_penalty.overflow_mode == -1)
 		options->per_source_penalty.overflow_mode = PER_SOURCE_PENALTY_OVERFLOW_PERMISSIVE;
+	if (options->per_source_penalty.overflow_mode6 == -1)
+		options->per_source_penalty.overflow_mode6 = options->per_source_penalty.overflow_mode;
 	if (options->per_source_penalty.penalty_crash == -1)
 		options->per_source_penalty.penalty_crash = 90;
 	if (options->per_source_penalty.penalty_grace == -1)
@@ -1971,9 +1977,14 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 			} else if (strncmp(arg, "min:", 4) == 0) {
 				p = arg + 4;
 				intptr = &options->per_source_penalty.penalty_min;
-			} else if (strncmp(arg, "max-sources:", 12) == 0) {
-				intptr = &options->per_source_penalty.max_sources;
-				if ((errstr = atoi_err(arg+12, &value)) != NULL)
+			} else if (strncmp(arg, "max-sources4:", 13) == 0) {
+				intptr = &options->per_source_penalty.max_sources4;
+				if ((errstr = atoi_err(arg+13, &value)) != NULL)
+					fatal("%s line %d: %s value %s.",
+					    filename, linenum, keyword, errstr);
+			} else if (strncmp(arg, "max-sources6:", 13) == 0) {
+				intptr = &options->per_source_penalty.max_sources6;
+				if ((errstr = atoi_err(arg+13, &value)) != NULL)
 					fatal("%s line %d: %s value %s.",
 					    filename, linenum, keyword, errstr);
 			} else if (strcmp(arg, "overflow:deny-all") == 0) {
@@ -1981,6 +1992,12 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 				value = PER_SOURCE_PENALTY_OVERFLOW_DENY_ALL;
 			} else if (strcmp(arg, "overflow:permissive") == 0) {
 				intptr = &options->per_source_penalty.overflow_mode;
+				value = PER_SOURCE_PENALTY_OVERFLOW_PERMISSIVE;
+			} else if (strcmp(arg, "overflow6:deny-all") == 0) {
+				intptr = &options->per_source_penalty.overflow_mode6;
+				value = PER_SOURCE_PENALTY_OVERFLOW_DENY_ALL;
+			} else if (strcmp(arg, "overflow6:permissive") == 0) {
+				intptr = &options->per_source_penalty.overflow_mode6;
 				value = PER_SOURCE_PENALTY_OVERFLOW_PERMISSIVE;
 			} else {
 				fatal("%s line %d: unsupported %s keyword %s",
@@ -3218,15 +3235,20 @@ dump_config(ServerOptions *o)
 
 	if (o->per_source_penalty.enabled) {
 		printf("persourcepenalties crash:%d authfail:%d noauth:%d "
-		    "grace-exceeded:%d max:%d min:%d max-sources:%d "
-		    "overflow:%s\n", o->per_source_penalty.penalty_crash,
+		    "grace-exceeded:%d max:%d min:%d max-sources4:%d "
+		    "max-sources6:%d overflow:%s overflow6:%s\n",
+		    o->per_source_penalty.penalty_crash,
 		    o->per_source_penalty.penalty_authfail,
 		    o->per_source_penalty.penalty_noauth,
 		    o->per_source_penalty.penalty_grace,
 		    o->per_source_penalty.penalty_max,
 		    o->per_source_penalty.penalty_min,
-		    o->per_source_penalty.max_sources,
+		    o->per_source_penalty.max_sources4,
+		    o->per_source_penalty.max_sources6,
 		    o->per_source_penalty.overflow_mode ==
+		    PER_SOURCE_PENALTY_OVERFLOW_DENY_ALL ?
+		    "deny-all" : "permissive",
+		    o->per_source_penalty.overflow_mode6 ==
 		    PER_SOURCE_PENALTY_OVERFLOW_DENY_ALL ?
 		    "deny-all" : "permissive");
 	} else

--- a/servconf.h
+++ b/servconf.h
@@ -69,8 +69,10 @@ struct listenaddr {
 #define PER_SOURCE_PENALTY_OVERFLOW_PERMISSIVE	2
 struct per_source_penalty {
 	int	enabled;
-	int	max_sources;
+	int	max_sources4;
+	int	max_sources6;
 	int	overflow_mode;
+	int	overflow_mode6;
 	int	penalty_crash;
 	int	penalty_grace;
 	int	penalty_authfail;

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -1603,12 +1603,14 @@ Repeated penalties will accumulate up to this maximum.
 .It Cm min:duration
 Specifies the minimum penalty that must accrue before enforcement begins
 (default: 15s).
-.It Cm max-sources:number
-Specifies the maximum number of penalise client address ranges to track
-(default: 65536).
+.It Cm max-sources4:number max-sources6:number
+Specifies the maximum number of client IPv4 and IPv6 address ranges to
+track for penalties (default: 65536 for both).
 .It Cm overflow:mode
 Controls how the server behaves when
-.Cm max-sources
+.Cm max-sources4
+or
+.Cm max-sources6
 is exceeded.
 There are two operating modes:
 .Cm deny-all ,
@@ -1618,6 +1620,14 @@ until a penalty expires, and
 .Cm permissive ,
 which allows new connections by removing existing penalties early
 (default: permissive).
+Note that client penalties below the
+.Cm min
+threshold count against the total number of tracked penalties.
+IPv4 and IPv6 addresses are tracked separately, so an overflow in one will
+not affect the other.
+.It Cm overflow6:mode
+Allows specifying a different overflow mode for IPv6 addresses.
+The default it to use the same overflow mode as was specified for IPv4.
 .El
 .It Cm PerSourcePenaltyExemptList
 Specifies a comma-separated list of addresses to exempt from penalties.


### PR DESCRIPTION
Use separate RB_TREEs for penalised IPv4 and IPv6 addresses with separate limits for each and optionally different overflow policies.