### PR TITLE
Add PerSourcePenalties class for invalid user auth

### DIFF
--- a/monitor.c
+++ b/monitor.c
@@ -132,7 +132,10 @@ static char *auth_submethod = NULL;
 static u_int session_id2_len = 0;
 static u_char *session_id2 = NULL;
 static pid_t monitor_child_pid;
+
+/* Used to set sshd-session exit status */
 int auth_attempted = 0;
+int auth_invalid_user = 0;
 
 struct mon_table {
 	enum monitor_reqtype type;
@@ -250,8 +253,11 @@ monitor_child_preauth(struct ssh *ssh, struct monitor *pmonitor)
 		    mon_dispatch, &ent) == 1);
 
 		/* Record that auth was attempted to set exit status later */
-		if ((ent->flags & MON_AUTH) != 0)
+		if ((ent->flags & MON_AUTH) != 0) {
 			auth_attempted = 1;
+			if (!authctxt->valid)
+				auth_invalid_user = 1;
+		}
 
 		/* Special handling for multiple required authentications */
 		if (options.num_auth_methods != 0) {

--- a/servconf.c
+++ b/servconf.c
@@ -154,6 +154,7 @@ initialize_server_options(ServerOptions *options)
 	options->per_source_penalty.penalty_crash = -1;
 	options->per_source_penalty.penalty_authfail = -1;
 	options->per_source_penalty.penalty_noauth = -1;
+	options->per_source_penalty.penalty_invalid_user = -1;
 	options->per_source_penalty.penalty_grace = -1;
 	options->per_source_penalty.penalty_max = -1;
 	options->per_source_penalty.penalty_min = -1;
@@ -407,6 +408,8 @@ fill_default_server_options(ServerOptions *options)
 		options->per_source_penalty.penalty_authfail = 5;
 	if (options->per_source_penalty.penalty_noauth == -1)
 		options->per_source_penalty.penalty_noauth = 1;
+	if (options->per_source_penalty.penalty_invalid_user == -1)
+		options->per_source_penalty.penalty_invalid_user = 8;
 	if (options->per_source_penalty.penalty_min == -1)
 		options->per_source_penalty.penalty_min = 15;
 	if (options->per_source_penalty.penalty_max == -1)
@@ -1968,6 +1971,9 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 			} else if (strncmp(arg, "noauth:", 7) == 0) {
 				p = arg + 7;
 				intptr = &options->per_source_penalty.penalty_noauth;
+			} else if (strncmp(arg, "invalid_user:", 13) == 0) {
+				p = arg + 13;
+				intptr = &options->per_source_penalty.penalty_invalid_user;
 			} else if (strncmp(arg, "grace-exceeded:", 15) == 0) {
 				p = arg + 15;
 				intptr = &options->per_source_penalty.penalty_grace;
@@ -3235,12 +3241,14 @@ dump_config(ServerOptions *o)
 
 	if (o->per_source_penalty.enabled) {
 		printf("persourcepenalties crash:%d authfail:%d noauth:%d "
-		    "grace-exceeded:%d max:%d min:%d max-sources4:%d "
-		    "max-sources6:%d overflow:%s overflow6:%s\n",
+		    "grace-exceeded:%d invalid_user:%d max:%d min:%d "
+		    "max-sources4:%d max-sources6:%d "
+		    "overflow:%s overflow6:%s\n",
 		    o->per_source_penalty.penalty_crash,
 		    o->per_source_penalty.penalty_authfail,
 		    o->per_source_penalty.penalty_noauth,
 		    o->per_source_penalty.penalty_grace,
+		    o->per_source_penalty.penalty_invalid_user,
 		    o->per_source_penalty.penalty_max,
 		    o->per_source_penalty.penalty_min,
 		    o->per_source_penalty.max_sources4,

--- a/servconf.h
+++ b/servconf.h
@@ -77,6 +77,7 @@ struct per_source_penalty {
 	int	penalty_grace;
 	int	penalty_authfail;
 	int	penalty_noauth;
+	int	penalty_invalid_user;
 	int	penalty_max;
 	int	penalty_min;
 };

--- a/srclimit.c
+++ b/srclimit.c
@@ -379,6 +379,10 @@ srclimit_penalise(struct xaddr *addr, int penalty_type)
 		penalty_secs = penalty_cfg.penalty_noauth;
 		reason = "penalty: connections without attempting authentication";
 		break;
+	case SRCLIMIT_PENALTY_BADUSER:
+		penalty_secs = penalty_cfg.penalty_invalid_user;
+		reason = "penalty: attempting authentication for invalid user";
+		break;
 	case SRCLIMIT_PENALTY_GRACE_EXCEEDED:
 		penalty_secs = penalty_cfg.penalty_crash;
 		reason = "penalty: exceeded LoginGraceTime";

--- a/srclimit.h
+++ b/srclimit.h
@@ -27,11 +27,13 @@ void	srclimit_done(int);
 #define SRCLIMIT_PENALTY_AUTHFAIL	2
 #define SRCLIMIT_PENALTY_GRACE_EXCEEDED	3
 #define SRCLIMIT_PENALTY_NOAUTH		4
+#define SRCLIMIT_PENALTY_BADUSER	5
 
 /* meaningful exit values, used by sshd listener for penalties */
 #define EXIT_LOGIN_GRACE	3	/* login grace period exceeded */
 #define EXIT_CHILD_CRASH	4	/* preauth child crashed */
 #define EXIT_AUTH_ATTEMPTED	5	/* at least one auth attempt made */
+#define EXIT_AUTH_BADUSER	6	/* userauth attempt with invalid user */
 
 void	srclimit_penalise(struct xaddr *, int);
 int	srclimit_penalty_check_allow(int, const char **);

--- a/sshd-session.c
+++ b/sshd-session.c
@@ -1357,7 +1357,7 @@ do_ssh2_kex(struct ssh *ssh)
 void
 cleanup_exit(int i)
 {
-	extern int auth_attempted; /* monitor.c */
+	extern int auth_attempted, auth_invalid_user; /* monitor.c */
 
 	if (the_active_state != NULL && the_authctxt != NULL) {
 		do_cleanup(the_active_state, the_authctxt);
@@ -1372,7 +1372,11 @@ cleanup_exit(int i)
 		}
 	}
 	/* Override default fatal exit value when auth was attempted */
-	if (i == 255 && auth_attempted)
-		_exit(EXIT_AUTH_ATTEMPTED);
+	if (i == 255) {
+		if (auth_invalid_user)
+			_exit(EXIT_AUTH_BADUSER);
+		if (auth_attempted)
+			_exit(EXIT_AUTH_ATTEMPTED);
+	}
 	_exit(i);
 }

--- a/sshd.c
+++ b/sshd.c
@@ -360,6 +360,13 @@ child_reap(struct early_child *child)
 			    (long)child->pid, child->id,
 			    child->early ? " (early)" : "");
 			break;
+		case EXIT_AUTH_BADUSER:
+			penalty_type = SRCLIMIT_PENALTY_BADUSER;
+			debug_f("preauth child %ld for %s exited "
+			    "after auth attempt against invalid user %s",
+			    (long)child->pid, child->id,
+			    child->early ? " (early)" : "");
+			break;
 		default:
 			penalty_type = SRCLIMIT_PENALTY_NOAUTH;
 			debug_f("preauth child %ld for %s exited "

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -1602,6 +1602,9 @@ scanning tools such as
 Specifies how long to refuse clients that fail to authenticate after
 .Cm LoginGraceTime
 (default: 10s).
+.It Cm invalid_user:duration
+Specifies how long to refuse clients that attempt to authentication against
+an invalid destination username (default: 8s).
 .It Cm max:duration
 Specifies the maximum time a particular source address range will be refused
 access for (default: 10m).


### PR DESCRIPTION
A really common thing to see in sshd logs is password guessers trying random accounts:                                              

```
Aug  6 15:28:04 haru sshd-session[66734]: Connection closed by invalid user centos 147.182.146.0 port 58996 [preauth]
Aug  6 15:33:14 haru sshd-session[40153]: Connection closed by invalid user data 147.182.146.0 port 40602 [preauth]
Aug  6 15:38:25 haru sshd-session[52165]: Connection closed by invalid user demo 147.182.146.0 port 48124 [preauth]
Aug  6 15:43:36 haru sshd-session[62194]: Connection closed by invalid user deploy 147.182.146.0 port 43166 [preauth]
Aug  6 15:48:47 haru sshd-session[78959]: Connection closed by invalid user dev 147.182.146.0 port 44930 [preauth]
```
                                                                                
So this is a reasonably good signal that the origin address is bad.             

This adds a PerSourcePenalties invalid_user class to penalise them, and sets the penalty just below the activation threshold so it will take >=2 subsequent attempts in <16 seconds to be penalised.    