### PR TITLE
Match argv

### DIFF
--- a/readconf.c
+++ b/readconf.c
@@ -683,11 +683,11 @@ expand_match_exec_or_include_path(const char *path, Options *options,
  * Parse and execute a Match directive.
  */
 static int
-match_cfg_line(Options *options, char **condition, struct passwd *pw,
-    const char *host_arg, const char *original_host, int final_pass,
-    int *want_final_pass, const char *filename, int linenum)
+match_cfg_line(Options *options, const char *full_line, int *acp, char ***avp,
+    struct passwd *pw, const char *host_arg, const char *original_host,
+    int final_pass, int *want_final_pass, const char *filename, int linenum)
 {
-	char *arg, *oattrib, *attrib, *cmd, *cp = *condition, *host, *criteria;
+	char *arg, *oattrib, *attrib, *cmd, *host, *criteria;
 	const char *ruser;
 	int r, this_result, result = 1, attributes = 0, negate;
 
@@ -707,11 +707,11 @@ match_cfg_line(Options *options, char **condition, struct passwd *pw,
 	}
 
 	debug2("checking match for '%s' host %s originally %s",
-	    cp, host, original_host);
-	while ((oattrib = attrib = strdelim(&cp)) && *attrib != '\0') {
+	    full_line, host, original_host);
+	while ((oattrib = attrib = argv_next(acp, avp)) != NULL) {
 		/* Terminate on comment */
 		if (*attrib == '#') {
-			cp = NULL; /* mark all arguments consumed */
+			argv_consume(acp);
 			break;
 		}
 		arg = criteria = NULL;
@@ -720,7 +720,8 @@ match_cfg_line(Options *options, char **condition, struct passwd *pw,
 			attrib++;
 		/* Criterion "all" has no argument and must appear alone */
 		if (strcasecmp(attrib, "all") == 0) {
-			if (attributes > 1 || ((arg = strdelim(&cp)) != NULL &&
+			if (attributes > 1 ||
+			    ((arg = argv_next(acp, avp)) != NULL &&
 			    *arg != '\0' && *arg != '#')) {
 				error("%.200s line %d: '%s' cannot be combined "
 				    "with other Match attributes",
@@ -729,7 +730,7 @@ match_cfg_line(Options *options, char **condition, struct passwd *pw,
 				goto out;
 			}
 			if (arg != NULL && *arg == '#')
-				cp = NULL; /* mark all arguments consumed */
+				argv_consume(acp); /* consume remaining args */
 			if (result)
 				result = negate ? 0 : 1;
 			goto out;
@@ -754,7 +755,7 @@ match_cfg_line(Options *options, char **condition, struct passwd *pw,
 			continue;
 		}
 		/* All other criteria require an argument */
-		if ((arg = strdelim(&cp)) == NULL ||
+		if ((arg = argv_next(acp, avp)) == NULL ||
 		    *arg == '\0' || *arg == '#') {
 			error("Missing Match criteria for %s", attrib);
 			result = -1;
@@ -841,7 +842,6 @@ match_cfg_line(Options *options, char **condition, struct passwd *pw,
  out:
 	if (result != -1)
 		debug2("match %sfound", result ? "" : "not ");
-	*condition = cp;
 	free(host);
 	return result;
 }
@@ -1784,8 +1784,8 @@ parse_pubkey_algos:
 			    "option");
 			goto out;
 		}
-		value = match_cfg_line(options, &str, pw, host, original_host,
-		    flags & SSHCONF_FINAL, want_final_pass,
+		value = match_cfg_line(options, str, &ac, &av, pw, host,
+		    original_host, flags & SSHCONF_FINAL, want_final_pass,
 		    filename, linenum);
 		if (value < 0) {
 			error("%.200s line %d: Bad Match condition", filename,
@@ -1793,13 +1793,6 @@ parse_pubkey_algos:
 			goto out;
 		}
 		*activep = (flags & SSHCONF_NEVERMATCH) ? 0 : value;
-		/*
-		 * If match_cfg_line() didn't consume all its arguments then
-		 * arrange for the extra arguments check below to fail.
-		 */
-
-		if (str == NULL || *str == '\0')
-			argv_consume(&ac);
 		break;
 
 	case oEscapeChar:

--- a/servconf.c
+++ b/servconf.c
@@ -962,43 +962,46 @@ match_test_missing_fatal(const char *criteria, const char *attrib)
  * not match.
  */
 static int
-match_cfg_line(char **condition, int line, struct connection_info *ci)
+match_cfg_line(const char *full_line, int *acp, char ***avp,
+    int line, struct connection_info *ci)
 {
 	int result = 1, attributes = 0, port;
-	char *arg, *attrib, *cp = *condition;
+	char *arg, *attrib;
 
 	if (ci == NULL)
-		debug3("checking syntax for 'Match %s'", cp);
-	else
+		debug3("checking syntax for 'Match %s'", full_line);
+	else {
 		debug3("checking match for '%s' user %s host %s addr %s "
-		    "laddr %s lport %d", cp, ci->user ? ci->user : "(null)",
+		    "laddr %s lport %d", full_line,
+		    ci->user ? ci->user : "(null)",
 		    ci->host ? ci->host : "(null)",
 		    ci->address ? ci->address : "(null)",
 		    ci->laddress ? ci->laddress : "(null)", ci->lport);
+	}
 
-	while ((attrib = strdelim(&cp)) && *attrib != '\0') {
+	while ((attrib = argv_next(acp, avp)) != NULL) {
 		/* Terminate on comment */
 		if (*attrib == '#') {
-			cp = NULL; /* mark all arguments consumed */
+			argv_consume(acp); /* mark all arguments consumed */
 			break;
 		}
 		arg = NULL;
 		attributes++;
 		/* Criterion "all" has no argument and must appear alone */
 		if (strcasecmp(attrib, "all") == 0) {
-			if (attributes > 1 || ((arg = strdelim(&cp)) != NULL &&
+			if (attributes > 1 ||
+			    ((arg = argv_next(acp, avp)) != NULL &&
 			    *arg != '\0' && *arg != '#')) {
 				error("'all' cannot be combined with other "
 				    "Match attributes");
 				return -1;
 			}
 			if (arg != NULL && *arg == '#')
-				cp = NULL; /* mark all arguments consumed */
-			*condition = cp;
+				argv_consume(acp); /* consume remaining args */
 			return 1;
 		}
 		/* All other criteria require an argument */
-		if ((arg = strdelim(&cp)) == NULL ||
+		if ((arg = argv_next(acp, avp)) == NULL ||
 		    *arg == '\0' || *arg == '#') {
 			error("Missing Match criteria for %s", attrib);
 			return -1;
@@ -1129,7 +1132,6 @@ match_cfg_line(char **condition, int line, struct connection_info *ci)
 	}
 	if (ci != NULL)
 		debug3("match %sfound", result ? "" : "not ");
-	*condition = cp;
 	return result;
 }
 
@@ -2250,7 +2252,7 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 		if (cmdline)
 			fatal("Match directive not supported as a command-line "
 			    "option");
-		value = match_cfg_line(&str, linenum,
+		value = match_cfg_line(str, &ac, &av, linenum,
 		    (*inc_flags & SSHCFG_NEVERMATCH ? NULL : connectinfo));
 		if (value < 0)
 			fatal("%s line %d: Bad Match condition", filename,
@@ -2261,12 +2263,6 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 		 * match block.
 		 */
 		*inc_flags &= ~SSHCFG_MATCH_ONLY;
-		/*
-		 * If match_cfg_line() didn't consume all its arguments then
-		 * arrange for the extra arguments check below to fail.
-		 */
-		if (str == NULL || *str == '\0')
-			argv_consume(&ac);
 		break;
 
 	case sPermitListen:

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -33,8 +33,8 @@
 .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 .\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-.\" $OpenBSD: ssh_config.5,v 1.399 2024/08/22 23:11:30 djm Exp $
-.Dd $Mdocdate: August 22 2024 $
+.\" $OpenBSD: ssh_config.5,v 1.400 2024/09/03 05:29:56 djm Exp $
+.Dd $Mdocdate: September 3 2024 $
 .Dt SSH_CONFIG 5
 .Os
 .Sh NAME
@@ -1182,7 +1182,12 @@ to unknown options that appear before it.
 Include the specified configuration file(s).
 Multiple pathnames may be specified and each pathname may contain
 .Xr glob 7
-wildcards and, for user configurations, shell-like
+wildcards,
+tokens as described in the
+.Sx TOKENS
+section, envrionment variables as described in the
+.Sx ENVIRONMENT VARIABLES
+section and, for user configurations, shell-like
 .Sq ~
 references to user home directories.
 Wildcards will be expanded and processed in lexical order.
@@ -2271,6 +2276,7 @@ The local username.
 .Cm ControlPath ,
 .Cm IdentityAgent ,
 .Cm IdentityFile ,
+.Cm Include ,
 .Cm KnownHostsCommand ,
 .Cm LocalForward ,
 .Cm Match exec ,
@@ -2319,6 +2325,7 @@ The keywords
 .Cm ControlPath ,
 .Cm IdentityAgent ,
 .Cm IdentityFile ,
+.Cm Include ,
 .Cm KnownHostsCommand ,
 and
 .Cm UserKnownHostsFile


### PR DESCRIPTION
Switch ssh_config `Match` processing over to argv tokeniser. Makes it possible to use proper shell quoting for `Match exec`