### PR TITLE
Allow specifying FIDO PIN at ssh-add time

### DIFF
--- a/PROTOCOL.u2f
+++ b/PROTOCOL.u2f
@@ -267,6 +267,15 @@ library for the key. The format of this constraint extension would be:
 This constraint-based approach does not present any compatibility
 problems.
 
+Another constraint extension allows specification of a FIDO PIN at
+the time the key is loaded to the agent, rather than requiring it be
+entered each time the key is used.
+
+	byte		SSH_AGENT_CONSTRAIN_EXTENSION
+	string		sk-pin@openssh.com
+	string		pin
+
+
 OpenSSH integration
 -------------------
 

--- a/authfd.h
+++ b/authfd.h
@@ -49,7 +49,8 @@ int	ssh_fetch_identitylist(int sock, struct ssh_identitylist **idlp);
 void	ssh_free_identitylist(struct ssh_identitylist *idl);
 int	ssh_add_identity_constrained(int sock, struct sshkey *key,
     const char *comment, u_int life, u_int confirm, const char *provider,
-    struct dest_constraint **dest_constraints, size_t ndest_constraints);
+    const char *pin, struct dest_constraint **dest_constraints,
+    size_t ndest_constraints);
 int	ssh_agent_has_key(int sock, const struct sshkey *key);
 int	ssh_remove_identity(int sock, const struct sshkey *key);
 int	ssh_update_card(int sock, int add, const char *reader_id,

--- a/ssh-add.1
+++ b/ssh-add.1
@@ -43,7 +43,7 @@
 .Nd adds private key identities to the OpenSSH authentication agent
 .Sh SYNOPSIS
 .Nm ssh-add
-.Op Fl CcDdKkLlNqvXx
+.Op Fl CcDdKkLlNPqvXx
 .Op Fl E Ar fingerprint_hash
 .Op Fl H Ar hostkey_file
 .Op Fl h Ar destination_constraint
@@ -230,6 +230,14 @@ will request that the agent automatically delete the certificate shortly
 after the certificate's expiry date.
 This flag suppresses this behaviour and does not specify a lifetime for
 certificates added to an agent.
+.It Fl P
+Causes
+.Nm
+to request a PIN for a FIDO key at the time it is added to the agent,
+where it will be used by default for the life of the key.
+This overrides the usual behaviour of
+.Xr ssh-agent 1
+requesting a PIN at each use of the key.
 .It Fl q
 Be quiet after a successful operation.
 .It Fl S Ar provider

--- a/sshconnect.c
+++ b/sshconnect.c
@@ -1734,7 +1734,7 @@ maybe_add_key_to_agent(const char *authfile, struct sshkey *private,
 	if ((r = ssh_add_identity_constrained(auth_sock, private,
 	    comment == NULL ? authfile : comment,
 	    options.add_keys_to_agent_lifespan,
-	    (options.add_keys_to_agent == 3), skprovider, NULL, 0)) == 0)
+	    (options.add_keys_to_agent == 3), skprovider, NULL, NULL, 0)) == 0)
 		debug("identity added to agent: %s", authfile);
 	else
 		debug("could not add identity to agent: %s (%d)", authfile, r);


### PR DESCRIPTION
This allows specifying a PIN for FIDO keys once when they are loaded via ssh-add, overriding the current behaviour of requiring a PIN each time the key is used.

This trades a weakening of the user-verification signal for the convenience of not having to enter PINs for each key invocation.