### PR TITLE
match_pattern() using a NFA

### DIFF
--- a/match.c
+++ b/match.c
@@ -13,6 +13,7 @@
  */
 /*
  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
+ * Copyright (c) 2026 Damien Miller.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,66 +49,105 @@
 #include "misc.h"
 
 /*
+ * Computes the epsilon closure of an NFA set.
+ * In our wildcard grammar, epsilon transitions only exist for '*' wildcards,
+ * allowing us to transition from state i to i+1 without consuming input.
+ *
+ * This function modifies 'states' in place.
+ */
+static void
+epsilon_closure(char *states, const char *pattern, size_t M)
+{
+	int changed = 1;
+	size_t i;
+
+	while (changed) {
+		changed = 0;
+		for (i = 0; i < M; i++) {
+			if (!states[i] || pattern[i] != '*')
+				continue;
+			/*
+			 * State i is active, and pattern[i] is '*',
+			 * so we can epsilon-transition to i+1.
+			 */
+			if (!states[i + 1]) {
+				states[i + 1] = 1;
+				changed = 1;
+			}
+		}
+	}
+}
+
+/*
  * Returns true if the given string matches the pattern (which may contain ?
  * and * as wildcards), and zero if it does not match.
  */
 int
 match_pattern(const char *s, const char *pattern)
 {
-	for (;;) {
-		/* If at end of pattern, accept if also at end of string. */
-		if (!*pattern)
-			return !*s;
+	size_t M;
+	size_t i;
+	char *states, *next_states, *tmp;
+	int active, matched = 0;
 
-		if (*pattern == '*') {
-			/* Skip this and any consecutive asterisks. */
-			while (*pattern == '*')
-				pattern++;
+	if ((M = strlen(pattern)) == 0)
+		return *s == '\0';
 
-			/* If at end of pattern, accept immediately. */
-			if (!*pattern)
-				return 1;
+	states = xcalloc(M + 1, sizeof(*states));
+	next_states = xcalloc(M + 1, sizeof(*next_states));
 
-			/* If next character in pattern is known, optimize. */
-			if (*pattern != '?' && *pattern != '*') {
+	/* Initial state: state 0 is active */
+	states[0] = 1;
+	/* Other states might be valid now if the pattern starts with '*' */
+	epsilon_closure(states, pattern, M);
+
+	for (; *s; s++) {
+		memset(next_states, 0, M + 1);
+
+		/* Calculate the reachable next states given the input char */
+		for (i = 0; i < M; i++) {
+			if (!states[i])
+				continue;
+			if (pattern[i] == '*') {
 				/*
-				 * Look instances of the next character in
-				 * pattern, and try to match starting from
-				 * those.
+				 * '*' matches any character, so we can
+				 * stay in state i
 				 */
-				for (; *s; s++)
-					if (*s == *pattern &&
-					    match_pattern(s + 1, pattern + 1))
-						return 1;
-				/* Failed. */
-				return 0;
+				next_states[i] = 1;
+			} else if (pattern[i] == '?' || pattern[i] == *s) {
+				/*
+				 * '?' matches any character, or we have
+				 * a literal match.
+				 */
+				next_states[i + 1] = 1;
 			}
-			/*
-			 * Move ahead one character at a time and try to
-			 * match at each position.
-			 */
-			for (; *s; s++)
-				if (match_pattern(s, pattern))
-					return 1;
-			/* Failed. */
-			return 0;
 		}
-		/*
-		 * There must be at least one more character in the string.
-		 * If we are at the end, fail.
-		 */
-		if (!*s)
-			return 0;
 
-		/* Check if the next character of the string is acceptable. */
-		if (*pattern != '?' && *pattern != *s)
-			return 0;
+		/* Expand the reachable next states with epsilon transitions */
+		epsilon_closure(next_states, pattern, M);
 
-		/* Move to the next character, both in string and in pattern. */
-		s++;
-		pattern++;
+		/* Swap states and next_states */
+		tmp = states;
+		states = next_states;
+		next_states = tmp;
+
+		/* Check if we have any active states left */
+		active = 0;
+		for (i = 0; i <= M; i++) {
+			if (states[i]) {
+				active = 1;
+				break;
+			}
+		}
+		if (!active)
+			goto out; /* No active states, fail early */
 	}
-	/* NOTREACHED */
+
+	matched = states[M];
+ out:
+	free(states);
+	free(next_states);
+	return matched;
 }
 
 /*

--- a/match.c
+++ b/match.c
@@ -58,23 +58,17 @@
 static void
 epsilon_closure(char *states, const char *pattern, size_t M)
 {
-	int changed = 1;
 	size_t i;
 
-	while (changed) {
-		changed = 0;
-		for (i = 0; i < M; i++) {
-			if (!states[i] || pattern[i] != '*')
-				continue;
-			/*
-			 * State i is active, and pattern[i] is '*',
-			 * so we can epsilon-transition to i+1.
-			 */
-			if (!states[i + 1]) {
-				states[i + 1] = 1;
-				changed = 1;
-			}
-		}
+	/* only need a forward pass as there are no back jumps in our grammar */
+	for (i = 0; i < M; i++) {
+		if (!states[i] || pattern[i] != '*')
+			continue;
+		/*
+		 * State i is active, and pattern[i] is '*', so we can
+		 * epsilon-transition to i+1.
+		 */
+		states[i + 1] = 1;
 	}
 }
 


### PR DESCRIPTION
This completely replaces match_pattern() with a version that uses a NFA (strictly a "NFA with epsilon moves"[1]) for matching. This turns out to be not terribly more complicated but fully avoids the exponential behaviour of the old match_pattern(), as well as the stack recursion.

https://swtch.com/~rsc/regexp/regexp1.html has a good overview of the theory as it applies to regular expressions. This is a much simpler case because we only support two wildcard types and only one that creates epsilon transitions ('*'). Russ also goes on to build a DFA from the NFA which gives O(n) performance but I don't think we need that complexity - in particular it uses much more memory.

With this, the worst-case time complexity is improved from O(2**n) to O(N * M) where N is the length of the input string and M is the length of the pattern. Memory use is bounded at 2x the length of the pattern, just to store the reachable states.